### PR TITLE
feat(backoffice-app): build role-aware internal operations demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ npm run serve:demo
 Open:
 
 - Web app: `http://localhost:4200`
+- Backoffice app: `http://localhost:4300`
 - Auth Swagger UI: `http://localhost:3003/swagger`
 - Users Swagger UI: `http://localhost:3001/swagger`
 - Payments Swagger UI: `http://localhost:3002/swagger`
@@ -141,6 +142,8 @@ Support and admin accounts still exist in `auth-service`, but they are intention
 
 - Support: `diana.miller@example.com` / `diana-demo-password`
 - Admin: `alice.johnson@example.com` / `alice-demo-password`
+
+Those internal personas now drive the operational workflows in `backoffice-app`.
 
 ## Useful Commands
 
@@ -176,10 +179,11 @@ nx run users-sdk:build
 nx run payments-sdk:build
 ```
 
-Build the consumer app:
+Build the consumer apps:
 
 ```bash
 nx build web-app
+nx build backoffice-app
 ```
 
 Inspect the project graph:
@@ -198,13 +202,14 @@ Integrated now:
 - GenX API generation from published contracts
 - independently releasable SDK packages
 - explicit package consumption in `web-app`
+- explicit package consumption in `backoffice-app`
 - app-owned session storage in `web-app`
+- app-owned session storage in `backoffice-app`
+- internal role-aware routing and navigation in `backoffice-app`
 - shared auth-service client helpers under `libs/auth-client`
 
 Not yet integrated:
 
-- `backoffice-app` login flow
-- `backoffice-app` making live SDK requests
 - `mobile-app` login flow
 - `mobile-app` making live SDK requests
 - a backend release automation tool such as semantic-release or Nx Release

--- a/apps/backoffice-app/src/App.tsx
+++ b/apps/backoffice-app/src/App.tsx
@@ -1,35 +1,169 @@
-import {
-  backofficeAuthServiceBaseUrl,
-  backofficePaymentsServiceBaseUrl,
-  backofficeUsersServiceBaseUrl,
-} from './runtime';
+import type { PropsWithChildren } from 'react';
+import { NavLink, Navigate, Route, Routes } from 'react-router-dom';
+import { useAuthSession } from './auth/AuthSessionContext';
+import AccessDeniedPage from './pages/AccessDeniedPage';
+import PaymentsPage from './pages/PaymentsPage';
+import SessionGatePage from './pages/SessionGatePage';
+import UserDetailsPage from './pages/UserDetailsPage';
+import UsersPage from './pages/UsersPage';
+import { formatLabel } from './utils/format';
+
+const linkClassName = ({ isActive }: { isActive: boolean }) =>
+  isActive ? 'nav-link active' : 'nav-link';
+
+const InternalRoute = ({ children }: PropsWithChildren) => {
+  const { isInternal } = useAuthSession();
+
+  if (!isInternal) {
+    return <SessionGatePage />;
+  }
+
+  return children;
+};
+
+const AdminRoute = ({ children }: PropsWithChildren) => {
+  const { isAdmin, isInternal } = useAuthSession();
+
+  if (!isInternal) {
+    return <SessionGatePage />;
+  }
+
+  if (!isAdmin) {
+    return <AccessDeniedPage />;
+  }
+
+  return children;
+};
 
 export default function App() {
+  const {
+    canViewPaymentsIndex,
+    isAuthenticated,
+    isInternal,
+    role,
+    signOut,
+    user,
+  } = useAuthSession();
+  const navigationItems = [
+    {
+      to: '/users',
+      label: 'Users',
+      description: 'Browse internal records and open case detail.',
+      isVisible: isInternal,
+    },
+    {
+      to: '/payments',
+      label: 'Payments',
+      description: 'Global payment queue for admin sessions.',
+      isVisible: canViewPaymentsIndex,
+    },
+  ].filter((item) => item.isVisible);
+  const defaultRoute = isInternal ? '/users' : '/session';
+
   return (
-    <div className="app">
-      <header>
-        <p className="eyebrow">genxapi ecosystem</p>
-        <h1>Backoffice App</h1>
-        <p className="subhead">
-          Internal console starter using the shared runtime config contract.
-        </p>
-      </header>
-      <section className="card">
-        <h2>Runtime Config</h2>
-        <ul>
-          <li>Auth service base URL: {backofficeAuthServiceBaseUrl}</li>
-          <li>Users SDK base URL: {backofficeUsersServiceBaseUrl}</li>
-          <li>Payments SDK base URL: {backofficePaymentsServiceBaseUrl}</li>
-        </ul>
-      </section>
-      <section className="card">
-        <h2>Adoption Model</h2>
-        <ul>
-          <li>Authenticate against auth-service and keep that session in the app shell.</li>
-          <li>Create the users and payments SDKs once from the stored token provider.</li>
-          <li>Keep app-specific login UX outside the generated SDK packages.</li>
-        </ul>
-      </section>
+    <div className="app-shell">
+      <aside className="sidebar">
+        <div className="brand">
+          <div className="brand-mark">BO</div>
+          <div className="stack">
+            <p className="eyebrow">genxapi ecosystem</p>
+            <h1>Backoffice App</h1>
+            <p className="sidebar-copy">
+              Internal operations consumer built on the same published contracts and generated SDKs
+              as the customer app.
+            </p>
+          </div>
+        </div>
+
+        <section className="sidebar-card">
+          <p className="label">Navigation</p>
+          {navigationItems.length > 0 ? (
+            <nav className="app-nav">
+              {navigationItems.map((item) => (
+                <NavLink key={item.to} className={linkClassName} to={item.to}>
+                  <span className="nav-link__label">{item.label}</span>
+                  <span className="nav-link__help">{item.description}</span>
+                </NavLink>
+              ))}
+            </nav>
+          ) : (
+            <p className="nav-empty">Choose a support or admin persona to unlock internal workflows.</p>
+          )}
+        </section>
+
+        <section className="sidebar-card session-card">
+          <p className="label">Demo session</p>
+          {isAuthenticated && user ? (
+            <div className="stack">
+              <div className="session-topline">
+                <p className="session-user">{user.name}</p>
+                <span className={`badge badge--${user.role}`}>{formatLabel(user.role)}</span>
+              </div>
+              <p className="muted">{user.email}</p>
+              <p className="muted">
+                {isInternal
+                  ? canViewPaymentsIndex
+                    ? 'Admin can browse users, user-level payments, and the global payments queue.'
+                    : 'Support can browse users and user-level payment history.'
+                  : 'Customer claims are not accepted in this internal app.'}
+              </p>
+              <button className="button button--secondary" type="button" onClick={signOut}>
+                Sign out
+              </button>
+            </div>
+          ) : (
+            <div className="stack">
+              <p className="session-user">No internal persona selected</p>
+              <p className="muted">
+                This app only exposes internal support and admin journeys. Customer self-service
+                remains in <code>web-app</code>.
+              </p>
+            </div>
+          )}
+        </section>
+
+        <section className="sidebar-card runtime-card">
+          <p className="label">SDK boundary</p>
+          <p className="value">Runtime-configured generated clients</p>
+          <p className="muted">
+            Base URLs and bearer token injection stay at the app boundary instead of inside page
+            components.
+          </p>
+          {role ? <p className="muted">Current claim: {formatLabel(role)}</p> : null}
+        </section>
+      </aside>
+
+      <main className="content">
+        <Routes>
+          <Route path="/" element={<Navigate replace to={defaultRoute} />} />
+          <Route path="/session" element={<SessionGatePage />} />
+          <Route
+            path="/users"
+            element={
+              <InternalRoute>
+                <UsersPage />
+              </InternalRoute>
+            }
+          />
+          <Route
+            path="/users/:userId"
+            element={
+              <InternalRoute>
+                <UserDetailsPage />
+              </InternalRoute>
+            }
+          />
+          <Route
+            path="/payments"
+            element={
+              <AdminRoute>
+                <PaymentsPage />
+              </AdminRoute>
+            }
+          />
+          <Route path="*" element={<Navigate replace to={defaultRoute} />} />
+        </Routes>
+      </main>
     </div>
   );
 }

--- a/apps/backoffice-app/src/api/sdk.ts
+++ b/apps/backoffice-app/src/api/sdk.ts
@@ -1,0 +1,23 @@
+import { users } from '@genxapi/ecosystem-users-sdk';
+import { payments } from 'genxapi-ecosystem-payments-sdk';
+import { getCurrentAuthAccessToken } from '../auth/auth-session';
+import { createBackofficeSdks } from '../runtime';
+
+const withSignal = (signal?: AbortSignal): RequestInit | undefined => (signal ? { signal } : undefined);
+
+const backofficeSdks = createBackofficeSdks(getCurrentAuthAccessToken);
+
+export type InternalUser = users.User;
+export type InternalPayment = payments.Payment;
+
+export const getInternalUsers = (signal?: AbortSignal) =>
+  backofficeSdks.users.getUsers(withSignal(signal));
+
+export const getInternalUser = (userId: number, signal?: AbortSignal) =>
+  backofficeSdks.users.getUser(userId, withSignal(signal));
+
+export const getInternalPayments = (signal?: AbortSignal) =>
+  backofficeSdks.payments.getPayments(withSignal(signal));
+
+export const getInternalUserPayments = (userId: number, signal?: AbortSignal) =>
+  backofficeSdks.payments.getUserPayments(userId, withSignal(signal));

--- a/apps/backoffice-app/src/auth/AuthSessionContext.tsx
+++ b/apps/backoffice-app/src/auth/AuthSessionContext.tsx
@@ -1,0 +1,94 @@
+import { isInternalRole, type LoginCredentials } from '@genxapi/ecosystem-auth-client';
+import {
+  createContext,
+  useContext,
+  useState,
+  type PropsWithChildren,
+} from 'react';
+import { queryClient } from '../query-client';
+import { backofficeAuthClient } from '../runtime';
+import { getErrorMessage } from '../utils/format';
+import {
+  loadAuthSessionState,
+  persistAuthSession,
+  toAuthSessionState,
+  type AuthSessionState,
+} from './auth-session';
+import { demoPersonas, type DemoPersona } from './demo-personas';
+
+interface AuthSessionContextValue extends AuthSessionState {
+  isPending: boolean;
+  error: string | null;
+  demoPersonas: DemoPersona[];
+  signInAsDemoPersona: (personaId: DemoPersona['id']) => Promise<boolean>;
+  signOut: () => void;
+}
+
+const AuthSessionContext = createContext<AuthSessionContextValue | null>(null);
+
+export const AuthSessionProvider = ({ children }: PropsWithChildren) => {
+  const [session, setSession] = useState(loadAuthSessionState);
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loginWithCredentials = async (credentials: LoginCredentials) => {
+    setIsPending(true);
+    setError(null);
+
+    try {
+      const nextSession = await backofficeAuthClient.login(credentials);
+
+      if (!isInternalRole(nextSession.user.role)) {
+        throw new Error('This backoffice app only supports support and admin demo personas.');
+      }
+
+      persistAuthSession(nextSession);
+      queryClient.clear();
+      setSession(toAuthSessionState(nextSession));
+      return true;
+    } catch (nextError) {
+      setError(getErrorMessage(nextError));
+      return false;
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const value: AuthSessionContextValue = {
+    ...session,
+    isPending,
+    error,
+    demoPersonas,
+    signInAsDemoPersona: async (personaId) => {
+      const persona = demoPersonas.find((entry) => entry.id === personaId);
+
+      if (!persona) {
+        setError('Unknown demo persona.');
+        return false;
+      }
+
+      return loginWithCredentials({
+        email: persona.email,
+        password: persona.password,
+      });
+    },
+    signOut: () => {
+      persistAuthSession(null);
+      queryClient.clear();
+      setError(null);
+      setSession(toAuthSessionState(null));
+    },
+  };
+
+  return <AuthSessionContext.Provider value={value}>{children}</AuthSessionContext.Provider>;
+};
+
+export const useAuthSession = () => {
+  const context = useContext(AuthSessionContext);
+
+  if (!context) {
+    throw new Error('useAuthSession must be used within AuthSessionProvider.');
+  }
+
+  return context;
+};

--- a/apps/backoffice-app/src/auth/auth-session.ts
+++ b/apps/backoffice-app/src/auth/auth-session.ts
@@ -1,0 +1,99 @@
+import {
+  AUTH_SESSION_STORAGE_KEY,
+  isInternalRole,
+  type AuthSession,
+  type UserRole,
+} from '@genxapi/ecosystem-auth-client';
+
+export interface AuthSessionState {
+  session: AuthSession | null;
+  user: AuthSession['user'] | null;
+  accessToken: string | null;
+  role: UserRole | null;
+  isAuthenticated: boolean;
+  isInternal: boolean;
+  isSupport: boolean;
+  isAdmin: boolean;
+  canViewUsers: boolean;
+  canViewUserPayments: boolean;
+  canViewPaymentsIndex: boolean;
+}
+
+const canUseStorage = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isAuthSession = (value: unknown): value is AuthSession => {
+  if (!isObject(value) || !isObject(value.user)) {
+    return false;
+  }
+
+  return (
+    typeof value.accessToken === 'string' &&
+    value.tokenType === 'Bearer' &&
+    typeof value.expiresIn === 'number' &&
+    typeof value.user.id === 'number' &&
+    typeof value.user.email === 'string' &&
+    typeof value.user.name === 'string' &&
+    typeof value.user.role === 'string'
+  );
+};
+
+export const toAuthSessionState = (session: AuthSession | null): AuthSessionState => {
+  const role = session?.user.role ?? null;
+  const isInternal = isInternalRole(role);
+  const isAdmin = role === 'admin';
+  const isSupport = role === 'support';
+
+  return {
+    session,
+    user: session?.user ?? null,
+    accessToken: session?.accessToken ?? null,
+    role,
+    isAuthenticated: session !== null,
+    isInternal,
+    isSupport,
+    isAdmin,
+    canViewUsers: isInternal,
+    canViewUserPayments: isInternal,
+    canViewPaymentsIndex: isAdmin,
+  };
+};
+
+export const loadStoredAuthSession = (): AuthSession | null => {
+  if (!canUseStorage()) {
+    return null;
+  }
+
+  const rawValue = window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY);
+
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(rawValue) as unknown;
+    return isAuthSession(parsedValue) ? parsedValue : null;
+  } catch {
+    return null;
+  }
+};
+
+export const loadAuthSessionState = (): AuthSessionState =>
+  toAuthSessionState(loadStoredAuthSession());
+
+export const persistAuthSession = (session: AuthSession | null) => {
+  if (!canUseStorage()) {
+    return;
+  }
+
+  if (!session) {
+    window.localStorage.removeItem(AUTH_SESSION_STORAGE_KEY);
+    return;
+  }
+
+  window.localStorage.setItem(AUTH_SESSION_STORAGE_KEY, JSON.stringify(session));
+};
+
+export const getCurrentAuthAccessToken = () => loadStoredAuthSession()?.accessToken ?? null;

--- a/apps/backoffice-app/src/auth/demo-personas.ts
+++ b/apps/backoffice-app/src/auth/demo-personas.ts
@@ -1,0 +1,29 @@
+import type { LoginCredentials, UserRole } from '@genxapi/ecosystem-auth-client';
+
+type InternalRole = Extract<UserRole, 'support' | 'admin'>;
+
+export interface DemoPersona extends LoginCredentials {
+  id: 'diana-miller' | 'alice-johnson';
+  name: string;
+  role: InternalRole;
+  description: string;
+}
+
+export const demoPersonas: DemoPersona[] = [
+  {
+    id: 'diana-miller',
+    name: 'Diana Miller',
+    role: 'support',
+    email: 'diana.miller@example.com',
+    password: 'diana-demo-password',
+    description: 'Support can browse internal users and inspect user-scoped payment history.',
+  },
+  {
+    id: 'alice-johnson',
+    name: 'Alice Johnson',
+    role: 'admin',
+    email: 'alice.johnson@example.com',
+    password: 'alice-demo-password',
+    description: 'Admin gets the full internal workflow, including the global payments queue.',
+  },
+];

--- a/apps/backoffice-app/src/main.tsx
+++ b/apps/backoffice-app/src/main.tsx
@@ -1,10 +1,22 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { AuthSessionProvider } from './auth/AuthSessionContext';
+import { queryClient } from './query-client';
 import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <AuthSessionProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AuthSessionProvider>
+      {import.meta.env.DEV ? <ReactQueryDevtools initialIsOpen={false} /> : null}
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/apps/backoffice-app/src/pages/AccessDeniedPage.tsx
+++ b/apps/backoffice-app/src/pages/AccessDeniedPage.tsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router-dom';
+import { useAuthSession } from '../auth/AuthSessionContext';
+import { formatLabel } from '../utils/format';
+
+export default function AccessDeniedPage() {
+  const { signOut, user } = useAuthSession();
+
+  return (
+    <div className="page">
+      <section className="card hero-panel">
+        <p className="eyebrow">Restricted View</p>
+        <h2>Payments queue is reserved for admins</h2>
+        <p className="subhead">
+          Support sessions can investigate a specific user and their payments, but the global
+          payments browse is intentionally limited to the admin persona in this app.
+        </p>
+      </section>
+
+      <section className="card">
+        <div className="stack">
+          <p className="muted">
+            Current session:{' '}
+            {user ? `${user.name} (${formatLabel(user.role)})` : 'No internal persona selected.'}
+          </p>
+          <div className="toolbar">
+            <Link className="button button--primary" to="/users">
+              Go to users
+            </Link>
+            <button className="button button--secondary" type="button" onClick={signOut}>
+              Switch persona
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/backoffice-app/src/pages/PaymentsPage.tsx
+++ b/apps/backoffice-app/src/pages/PaymentsPage.tsx
@@ -1,0 +1,136 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { getInternalPayments } from '../api/sdk';
+import { formatCurrency, formatDateTime, formatLabel, getErrorMessage } from '../utils/format';
+
+export default function PaymentsPage() {
+  const paymentsQuery = useQuery({
+    queryKey: ['internal', 'payments'],
+    queryFn: ({ signal }) => getInternalPayments(signal),
+  });
+
+  const payments = [...(paymentsQuery.data ?? [])].sort(
+    (left, right) => new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime()
+  );
+  const totalAmount = payments.reduce((sum, payment) => sum + payment.amount, 0);
+  const currency = payments[0]?.currency ?? 'USD';
+  const pendingCount = payments.filter((payment) => payment.status === 'pending').length;
+  const uniqueUsersCount = new Set(payments.map((payment) => payment.userId)).size;
+
+  return (
+    <div className="page">
+      <section className="card hero-panel">
+        <div className="page-header">
+          <div>
+            <p className="eyebrow">Payments Workflow</p>
+            <h2>Admin payments queue</h2>
+            <p className="subhead">
+              This screen uses the generated payments SDK via <code>/payments</code> and is only
+              exposed to admin claims inside the backoffice app.
+            </p>
+          </div>
+          <div className="toolbar">
+            <Link className="button button--secondary" to="/users">
+              Back to users
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {paymentsQuery.isLoading ? (
+        <section className="card">
+          <p className="state">Loading internal payments…</p>
+        </section>
+      ) : null}
+
+      {paymentsQuery.isError ? (
+        <section className="card">
+          <p className="state error">Error: {getErrorMessage(paymentsQuery.error)}</p>
+        </section>
+      ) : null}
+
+      {!paymentsQuery.isLoading && !paymentsQuery.isError ? (
+        <>
+          <div className="summary-grid">
+            <section className="card summary-card">
+              <p className="label">Payments</p>
+              <p className="value">{payments.length}</p>
+              <p className="muted">Global records returned by the internal payments route.</p>
+            </section>
+            <section className="card summary-card">
+              <p className="label">Total amount</p>
+              <p className="value">{formatCurrency(totalAmount, currency)}</p>
+              <p className="muted">Sum of every payment record in the queue.</p>
+            </section>
+            <section className="card summary-card">
+              <p className="label">Users touched</p>
+              <p className="value">{uniqueUsersCount}</p>
+              <p className="muted">Distinct owning users represented in this list.</p>
+            </section>
+            <section className="card summary-card">
+              <p className="label">Pending</p>
+              <p className="value">{pendingCount}</p>
+              <p className="muted">Pending payments remain visible only to admin in this UI.</p>
+            </section>
+          </div>
+
+          {payments.length === 0 ? (
+            <section className="card">
+              <h3>No payments found</h3>
+              <p className="state">The internal payments route returned an empty dataset.</p>
+            </section>
+          ) : (
+            <section className="card">
+              <div className="card-header">
+                <div>
+                  <h3>Payment records</h3>
+                  <p className="muted">
+                    Use the linked user ids to pivot back into the internal user workflow.
+                  </p>
+                </div>
+              </div>
+              <div className="table-wrap">
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th>Payment</th>
+                      <th>User</th>
+                      <th>Created</th>
+                      <th>Amount</th>
+                      <th>Status</th>
+                      <th>Method</th>
+                      <th>Transaction</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {payments.map((payment) => (
+                      <tr key={payment.id}>
+                        <td>#{payment.id}</td>
+                        <td>
+                          <Link className="inline-link" to={`/users/${payment.userId}`}>
+                            User {payment.userId}
+                          </Link>
+                        </td>
+                        <td>{formatDateTime(payment.createdAt)}</td>
+                        <td>{formatCurrency(payment.amount, payment.currency)}</td>
+                        <td>
+                          <span className={`badge badge--${payment.status}`}>
+                            {formatLabel(payment.status)}
+                          </span>
+                        </td>
+                        <td>{formatLabel(payment.method)}</td>
+                        <td>
+                          <code>{payment.transactionId}</code>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/backoffice-app/src/pages/SessionGatePage.tsx
+++ b/apps/backoffice-app/src/pages/SessionGatePage.tsx
@@ -1,0 +1,110 @@
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuthSession } from '../auth/AuthSessionContext';
+import {
+  backofficeAuthServiceBaseUrl,
+  backofficePaymentsServiceBaseUrl,
+  backofficeUsersServiceBaseUrl,
+} from '../runtime';
+import { formatLabel } from '../utils/format';
+
+export default function SessionGatePage() {
+  const navigate = useNavigate();
+  const { demoPersonas, error, isAuthenticated, isInternal, isPending, signInAsDemoPersona, signOut, user } =
+    useAuthSession();
+
+  const title = isInternal
+    ? 'Internal session ready'
+    : isAuthenticated
+      ? 'Switch to an internal persona'
+      : 'Choose an internal demo session';
+  const description = isInternal
+    ? 'This backoffice app authenticates against auth-service, then routes internal users and payments calls through the generated SDK layer.'
+    : isAuthenticated
+      ? 'Customer claims are not valid here. Pick a support or admin persona to unlock internal workflows.'
+      : 'Each button signs into auth-service with a seeded support or admin account. The app does not build a separate login product flow.';
+
+  return (
+    <div className="page">
+      <section className="card hero-panel">
+        <p className="eyebrow">Internal Access</p>
+        <h2>{title}</h2>
+        <p className="subhead">{description}</p>
+        {isAuthenticated && user && !isInternal ? (
+          <p className="state error">
+            Current session: {user.name} ({formatLabel(user.role)}). Customer claims are blocked in
+            the backoffice app.
+          </p>
+        ) : null}
+        {isInternal && user ? (
+          <div className="toolbar">
+            <Link className="button button--primary" to="/users">
+              Continue to operations
+            </Link>
+            <button className="button button--secondary" type="button" onClick={signOut}>
+              Clear session
+            </button>
+          </div>
+        ) : null}
+      </section>
+
+      <div className="persona-grid">
+        {demoPersonas.map((persona) => {
+          const isCurrent = isInternal && user?.email === persona.email;
+
+          return (
+            <section
+              key={persona.id}
+              className={isCurrent ? 'card persona-card persona-card--active' : 'card persona-card'}
+            >
+              <div className="persona-header">
+                <div>
+                  <p className="label">Demo persona</p>
+                  <h3>{persona.name}</h3>
+                </div>
+                <span className={`badge badge--${persona.role}`}>{formatLabel(persona.role)}</span>
+              </div>
+              <div className="stack persona-meta">
+                <p className="value">{persona.email}</p>
+                <p className="muted">{persona.description}</p>
+              </div>
+              <button
+                className="button button--primary"
+                type="button"
+                onClick={async () => {
+                  const didSignIn = await signInAsDemoPersona(persona.id);
+
+                  if (didSignIn) {
+                    navigate('/users');
+                  }
+                }}
+                disabled={isPending || isCurrent}
+              >
+                {isCurrent ? 'Current session' : isPending ? 'Starting session…' : `Use ${persona.name}`}
+              </button>
+            </section>
+          );
+        })}
+      </div>
+
+      <section className="card">
+        <h3>Runtime notes</h3>
+        <div className="stack">
+          <p className="muted">Auth service: {backofficeAuthServiceBaseUrl}</p>
+          <p className="muted">Users SDK base URL: {backofficeUsersServiceBaseUrl}</p>
+          <p className="muted">Payments SDK base URL: {backofficePaymentsServiceBaseUrl}</p>
+          <p className="muted">
+            This app stays on internal routes such as <code>/users</code>, <code>/users/:id</code>,
+            and <code>/payments</code>. Customer-only <code>/me</code> flows remain in{' '}
+            <code>web-app</code>.
+          </p>
+          {isAuthenticated && user && !isInternal ? (
+            <button className="button button--secondary" type="button" onClick={signOut}>
+              Remove invalid session
+            </button>
+          ) : null}
+          {error ? <p className="state error">Error: {error}</p> : null}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/backoffice-app/src/pages/UserDetailsPage.tsx
+++ b/apps/backoffice-app/src/pages/UserDetailsPage.tsx
@@ -1,0 +1,205 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link, useParams } from 'react-router-dom';
+import { getInternalUser, getInternalUserPayments } from '../api/sdk';
+import { useAuthSession } from '../auth/AuthSessionContext';
+import { formatCurrency, formatDateTime, formatLabel, getErrorMessage } from '../utils/format';
+
+export default function UserDetailsPage() {
+  const { userId } = useParams();
+  const { canViewPaymentsIndex, canViewUserPayments } = useAuthSession();
+  const parsedUserId = Number(userId);
+  const isValidUserId = Number.isInteger(parsedUserId) && parsedUserId > 0;
+
+  const userQuery = useQuery({
+    queryKey: ['internal', 'users', parsedUserId],
+    enabled: isValidUserId,
+    queryFn: ({ signal }) => getInternalUser(parsedUserId, signal),
+  });
+
+  const paymentsQuery = useQuery({
+    queryKey: ['internal', 'users', parsedUserId, 'payments'],
+    enabled: isValidUserId && canViewUserPayments,
+    queryFn: ({ signal }) => getInternalUserPayments(parsedUserId, signal),
+  });
+
+  const payments = [...(paymentsQuery.data ?? [])].sort(
+    (left, right) => new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime()
+  );
+  const totalAmount = payments.reduce((sum, payment) => sum + payment.amount, 0);
+  const currency = payments[0]?.currency ?? 'USD';
+  const title = userQuery.data
+    ? `${userQuery.data.firstName} ${userQuery.data.lastName}`
+    : isValidUserId
+      ? `User ${parsedUserId}`
+      : 'Unknown user';
+
+  return (
+    <div className="page">
+      <section className="card hero-panel">
+        <div className="page-header">
+          <div>
+            <p className="eyebrow">User Detail</p>
+            <h2>{title}</h2>
+            <p className="subhead">
+              This internal record comes from the generated users SDK via <code>/users/:userId</code>.
+              User-scoped payments load through <code>/users/:userId/payments</code>.
+            </p>
+          </div>
+          <div className="toolbar">
+            <Link className="button button--secondary" to="/users">
+              Back to users
+            </Link>
+            {canViewPaymentsIndex ? (
+              <Link className="button button--primary" to="/payments">
+                Open payments queue
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      {!isValidUserId ? (
+        <section className="card">
+          <p className="state error">The user id in the URL is not valid.</p>
+        </section>
+      ) : null}
+
+      {isValidUserId && userQuery.isLoading ? (
+        <section className="card">
+          <p className="state">Loading user record…</p>
+        </section>
+      ) : null}
+
+      {isValidUserId && userQuery.isError ? (
+        <section className="card">
+          <p className="state error">Error: {getErrorMessage(userQuery.error)}</p>
+        </section>
+      ) : null}
+
+      {isValidUserId && !userQuery.isLoading && !userQuery.isError && userQuery.data ? (
+        <>
+          <div className="grid">
+            <section className="card">
+              <div className="card-header">
+                <h3>Account details</h3>
+                <span className={`badge badge--${userQuery.data.role}`}>
+                  {formatLabel(userQuery.data.role)}
+                </span>
+              </div>
+              <dl className="detail-list">
+                <div className="detail-row">
+                  <dt className="label">Full name</dt>
+                  <dd className="value">{`${userQuery.data.firstName} ${userQuery.data.lastName}`}</dd>
+                </div>
+                <div className="detail-row">
+                  <dt className="label">Email</dt>
+                  <dd className="value">{userQuery.data.email}</dd>
+                </div>
+                <div className="detail-row">
+                  <dt className="label">Status</dt>
+                  <dd className="value">
+                    <span className={userQuery.data.isActive ? 'badge badge--active' : 'badge badge--inactive'}>
+                      {userQuery.data.isActive ? 'Active' : 'Inactive'}
+                    </span>
+                  </dd>
+                </div>
+                <div className="detail-row">
+                  <dt className="label">Created</dt>
+                  <dd className="value">{formatDateTime(userQuery.data.createdAt)}</dd>
+                </div>
+                <div className="detail-row">
+                  <dt className="label">User id</dt>
+                  <dd className="value">User {userQuery.data.id}</dd>
+                </div>
+              </dl>
+            </section>
+
+            <section className="card">
+              <h3>Operational scope</h3>
+              <div className="stack">
+                <div className="summary-card">
+                  <p className="label">Current workflow</p>
+                  <p className="value">
+                    {canViewPaymentsIndex ? 'Admin operations' : 'Support investigation'}
+                  </p>
+                  <p className="muted">
+                    Claims control both the visible navigation and the route guards in this app.
+                  </p>
+                </div>
+                <div className="summary-card">
+                  <p className="label">User payments</p>
+                  <p className="value">{payments.length}</p>
+                  <p className="muted">
+                    {payments.length > 0
+                      ? `Total amount: ${formatCurrency(totalAmount, currency)}`
+                      : 'No payments returned for this user.'}
+                  </p>
+                </div>
+                <div className="summary-card">
+                  <p className="label">Global payments queue</p>
+                  <p className="value">{canViewPaymentsIndex ? 'Available' : 'Hidden for support'}</p>
+                  <p className="muted">
+                    Support stays on user-scoped lookups. Admin can also browse the full payments list.
+                  </p>
+                </div>
+              </div>
+            </section>
+          </div>
+
+          {canViewUserPayments ? (
+            <section className="card">
+              <div className="card-header">
+                <div>
+                  <h3>User payments</h3>
+                  <p className="muted">
+                    Internal payment history returned for user {userQuery.data.id}.
+                  </p>
+                </div>
+              </div>
+
+              {paymentsQuery.isLoading ? <p className="state">Loading user payments…</p> : null}
+              {paymentsQuery.isError ? (
+                <p className="state error">Error: {getErrorMessage(paymentsQuery.error)}</p>
+              ) : null}
+              {!paymentsQuery.isLoading && !paymentsQuery.isError && payments.length === 0 ? (
+                <p className="state">This user does not have payment history in the demo dataset.</p>
+              ) : null}
+              {!paymentsQuery.isLoading && !paymentsQuery.isError && payments.length > 0 ? (
+                <div className="table-wrap">
+                  <table className="table">
+                    <thead>
+                      <tr>
+                        <th>Created</th>
+                        <th>Amount</th>
+                        <th>Status</th>
+                        <th>Method</th>
+                        <th>Transaction</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {payments.map((payment) => (
+                        <tr key={payment.id}>
+                          <td>{formatDateTime(payment.createdAt)}</td>
+                          <td>{formatCurrency(payment.amount, payment.currency)}</td>
+                          <td>
+                            <span className={`badge badge--${payment.status}`}>
+                              {formatLabel(payment.status)}
+                            </span>
+                          </td>
+                          <td>{formatLabel(payment.method)}</td>
+                          <td>
+                            <code>{payment.transactionId}</code>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/backoffice-app/src/pages/UsersPage.tsx
+++ b/apps/backoffice-app/src/pages/UsersPage.tsx
@@ -1,0 +1,129 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { getInternalUsers } from '../api/sdk';
+import { useAuthSession } from '../auth/AuthSessionContext';
+import { formatDateTime, formatLabel, getErrorMessage } from '../utils/format';
+
+export default function UsersPage() {
+  const { canViewPaymentsIndex, role } = useAuthSession();
+  const usersQuery = useQuery({
+    queryKey: ['internal', 'users'],
+    queryFn: ({ signal }) => getInternalUsers(signal),
+  });
+
+  const users = [...(usersQuery.data ?? [])].sort((left, right) => left.id - right.id);
+  const internalCount = users.filter((user) => user.role !== 'customer').length;
+  const customerCount = users.filter((user) => user.role === 'customer').length;
+  const inactiveCount = users.filter((user) => !user.isActive).length;
+
+  return (
+    <div className="page">
+      <section className="card hero-panel">
+        <p className="eyebrow">Users Workflow</p>
+        <h2>{canViewPaymentsIndex ? 'Internal user directory' : 'Support case directory'}</h2>
+        <p className="subhead">
+          The users list is loaded from the generated users SDK via <code>/users</code>. Visible
+          workflows follow the stored <code>{formatLabel(role ?? undefined)}</code> claim instead of
+          treating backoffice as a public app.
+        </p>
+      </section>
+
+      {usersQuery.isLoading ? (
+        <section className="card">
+          <p className="state">Loading internal users…</p>
+        </section>
+      ) : null}
+
+      {usersQuery.isError ? (
+        <section className="card">
+          <p className="state error">Error: {getErrorMessage(usersQuery.error)}</p>
+        </section>
+      ) : null}
+
+      {!usersQuery.isLoading && !usersQuery.isError ? (
+        <>
+          <div className="summary-grid">
+            <section className="card summary-card">
+              <p className="label">Users</p>
+              <p className="value">{users.length}</p>
+              <p className="muted">All internal records returned by the current demo dataset.</p>
+            </section>
+            <section className="card summary-card">
+              <p className="label">Customers</p>
+              <p className="value">{customerCount}</p>
+              <p className="muted">Customer accounts appear here for internal case lookup.</p>
+            </section>
+            <section className="card summary-card">
+              <p className="label">Internal staff</p>
+              <p className="value">{internalCount}</p>
+              <p className="muted">Support and admin personas are visible in the same directory.</p>
+            </section>
+            <section className="card summary-card">
+              <p className="label">Inactive</p>
+              <p className="value">{inactiveCount}</p>
+              <p className="muted">
+                {canViewPaymentsIndex
+                  ? 'Admins can pivot from this directory into the global payments queue.'
+                  : 'Support stays on user-focused workflows and user payment drill-downs.'}
+              </p>
+            </section>
+          </div>
+
+          {users.length === 0 ? (
+            <section className="card">
+              <h3>No users found</h3>
+              <p className="state">The internal users route returned an empty dataset.</p>
+            </section>
+          ) : (
+            <section className="card">
+              <div className="card-header">
+                <div>
+                  <h3>Internal records</h3>
+                  <p className="muted">
+                    Open a user to inspect account details and route-aligned payment history.
+                  </p>
+                </div>
+              </div>
+              <div className="table-wrap">
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th>User</th>
+                      <th>Email</th>
+                      <th>Role</th>
+                      <th>Status</th>
+                      <th>Created</th>
+                      <th />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {users.map((user) => (
+                      <tr key={user.id}>
+                        <td>{`${user.firstName} ${user.lastName}`}</td>
+                        <td>{user.email}</td>
+                        <td>
+                          <span className={`badge badge--${user.role}`}>{formatLabel(user.role)}</span>
+                        </td>
+                        <td>
+                          <span className={user.isActive ? 'badge badge--active' : 'badge badge--inactive'}>
+                            {user.isActive ? 'Active' : 'Inactive'}
+                          </span>
+                        </td>
+                        <td>{formatDateTime(user.createdAt)}</td>
+                        <td>
+                          <Link className="inline-link" to={`/users/${user.id}`}>
+                            Open record
+                          </Link>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/backoffice-app/src/query-client.ts
+++ b/apps/backoffice-app/src/query-client.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/apps/backoffice-app/src/styles.css
+++ b/apps/backoffice-app/src/styles.css
@@ -1,7 +1,21 @@
 :root {
+  --ink-strong: #f3f4f6;
+  --ink-soft: #cbd5e1;
+  --copy: #0f172a;
+  --copy-soft: #475569;
+  --line: #dbe3ee;
+  --panel: rgba(255, 255, 255, 0.92);
+  --panel-strong: #ffffff;
+  --sidebar: #121826;
+  --sidebar-line: rgba(148, 163, 184, 0.18);
+  --accent: #f59e0b;
+  --accent-soft: rgba(245, 158, 11, 0.16);
+  --shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
   font-family: 'IBM Plex Sans', system-ui, sans-serif;
-  color: #0f172a;
-  background: #f8fafc;
+  color: var(--copy);
+  background:
+    radial-gradient(circle at top right, rgba(245, 158, 11, 0.14), transparent 24%),
+    linear-gradient(180deg, #eef2f7 0%, #dde6f0 100%);
 }
 
 * {
@@ -10,44 +24,444 @@
 
 body {
   margin: 0;
-}
-
-.app {
   min-height: 100vh;
-  padding: 64px 8vw;
-  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 60%, #cbd5f5 100%);
+  background:
+    radial-gradient(circle at top right, rgba(245, 158, 11, 0.14), transparent 24%),
+    linear-gradient(180deg, #eef2f7 0%, #dde6f0 100%);
 }
 
-header {
-  max-width: 640px;
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
-.eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: 0.75rem;
-  color: #475569;
+code {
+  font-family: 'SFMono-Regular', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.92em;
 }
 
 h1 {
-  font-size: clamp(2.4rem, 5vw, 3.4rem);
-  margin: 12px 0 8px;
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.8rem);
+  color: #ffffff;
 }
 
-.subhead {
-  font-size: 1.05rem;
-  color: #475569;
+h2 {
+  margin: 0 0 10px;
+  font-size: 1.5rem;
 }
 
-.card {
-  margin-top: 32px;
-  padding: 24px;
-  border-radius: 14px;
-  background: #ffffff;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+h3 {
+  margin: 0 0 10px;
+  font-size: 1.12rem;
 }
 
-ul {
-  padding-left: 20px;
+.app-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+}
+
+.sidebar {
+  padding: 36px 24px;
+  background:
+    radial-gradient(circle at top right, rgba(245, 158, 11, 0.22), transparent 28%),
+    linear-gradient(180deg, #182030 0%, #121826 100%);
+  color: var(--ink-strong);
+  border-right: 1px solid var(--sidebar-line);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.brand {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.brand-mark {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.9), rgba(249, 115, 22, 0.85));
+  color: #111827;
+  box-shadow: 0 14px 30px rgba(245, 158, 11, 0.18);
+}
+
+.sidebar-copy {
+  margin: 0;
+  color: var(--ink-soft);
+  line-height: 1.55;
+}
+
+.content {
+  padding: 40px clamp(20px, 4vw, 48px);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: var(--copy-soft);
+}
+
+.sidebar .eyebrow {
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.page-header,
+.card-header,
+.session-topline,
+.persona-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.subhead,
+.muted {
+  margin: 0;
+  color: var(--copy-soft);
+  line-height: 1.55;
+}
+
+.sidebar .muted {
+  color: var(--ink-soft);
+}
+
+.card,
+.sidebar-card {
+  padding: 20px;
+  border-radius: 20px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(8px);
+}
+
+.sidebar-card {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: var(--sidebar-line);
+  box-shadow: none;
+}
+
+.hero-panel {
+  background:
+    linear-gradient(135deg, rgba(245, 158, 11, 0.1), rgba(15, 23, 42, 0.03)),
+    var(--panel-strong);
+}
+
+.runtime-card .value,
+.summary-card .value,
+.detail-list .value,
+.persona-card .value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--copy);
+}
+
+.sidebar .value {
+  color: #ffffff;
+}
+
+.label {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--copy-soft);
+}
+
+.sidebar .label {
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.app-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nav-link {
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(255, 255, 255, 0.03);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-link:hover {
+  border-color: rgba(245, 158, 11, 0.5);
+  background: rgba(245, 158, 11, 0.08);
+  transform: translateX(2px);
+}
+
+.nav-link.active {
+  border-color: rgba(245, 158, 11, 0.55);
+  background: var(--accent-soft);
+}
+
+.nav-link__label {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.nav-link__help,
+.nav-empty {
+  color: var(--ink-soft);
+  line-height: 1.45;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.grid,
+.summary-grid,
+.persona-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.grid {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.summary-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.persona-grid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.summary-card,
+.persona-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.persona-card--active {
+  border-color: rgba(245, 158, 11, 0.45);
+  box-shadow: 0 18px 44px rgba(245, 158, 11, 0.14);
+}
+
+.persona-meta {
+  flex: 1;
+}
+
+.toolbar {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.button {
+  border: 0;
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.button--primary {
+  background: #111827;
+  color: #ffffff;
+}
+
+.button--secondary {
+  background: #e2e8f0;
+  color: #111827;
+}
+
+.table-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 12px;
+  border-bottom: 1px solid #e2e8f0;
+  vertical-align: top;
+}
+
+.table thead {
+  background: #f8fafc;
+  color: var(--copy-soft);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.table tbody tr:hover {
+  background: rgba(245, 158, 11, 0.04);
+}
+
+.detail-list {
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.detail-row {
+  display: grid;
+  gap: 6px;
+}
+
+.detail-row dt,
+.detail-row dd {
+  margin: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: #e2e8f0;
+  color: #334155;
+}
+
+.badge--customer {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.badge--support {
+  background: #cffafe;
+  color: #0f766e;
+}
+
+.badge--admin {
+  background: #fde68a;
+  color: #92400e;
+}
+
+.badge--active {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.badge--inactive {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.badge--pending {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.badge--completed {
+  background: #dbeafe;
+  color: #1e3a8a;
+}
+
+.badge--failed {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.badge--refunded {
+  background: #ede9fe;
+  color: #5b21b6;
+}
+
+.inline-link {
+  color: #b45309;
+  font-weight: 700;
+}
+
+.inline-link:hover {
+  color: #92400e;
+}
+
+.session-user {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.state {
+  margin: 0;
+  color: var(--copy-soft);
+}
+
+.state.error {
+  color: #b91c1c;
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--sidebar-line);
+  }
+}
+
+@media (max-width: 640px) {
+  .sidebar,
+  .content {
+    padding: 24px 16px;
+  }
+
+  .card,
+  .sidebar-card {
+    padding: 16px;
+    border-radius: 16px;
+  }
+
+  .table th,
+  .table td {
+    padding: 10px;
+  }
 }

--- a/apps/backoffice-app/src/utils/format.ts
+++ b/apps/backoffice-app/src/utils/format.ts
@@ -1,0 +1,46 @@
+export const formatDateTime = (value?: string | number): string => {
+  if (value === undefined || value === null) {
+    return '—';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+
+  return date.toLocaleString();
+};
+
+export const formatCurrency = (amount: number, currency = 'USD'): string => {
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+    }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+};
+
+export const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  return 'Something went wrong.';
+};
+
+export const formatLabel = (value?: string): string => {
+  if (!value) {
+    return '—';
+  }
+
+  return value
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "serve:web-app": "nx serve web-app",
     "serve:backoffice-app": "nx serve backoffice-app",
     "serve:mobile-app": "nx serve mobile-app",
-    "serve:demo": "nx run-many --target=serve --projects=auth-service,users-service,payments-service,web-app --parallel=4",
+    "serve:demo": "nx run-many --target=serve --projects=auth-service,users-service,payments-service,web-app,backoffice-app --parallel=5",
     "swagger:export:auth": "nx run auth-service:export-swagger",
     "swagger:export:payments": "nx run payments-service:export-swagger",
     "swagger:export:users": "nx run users-service:export-swagger",


### PR DESCRIPTION
We turned `backoffice-app` from a placeholder into the internal operations consumer for the role-aware demo.

This PR:
- replaces the placeholder UI with a routed backoffice shell built for internal workflows
- adds demo persona bootstrap for `support` and `admin` using the existing `auth-service`
- rejects `customer` sessions as invalid for the backoffice app
- consumes the Phase 2 runtime-configured generated SDK layer for users and payments
- adds internal flows for users list, user details, user payment drill-down, and admin payments list
- derives visible navigation and route access from role claims instead of treating the app like a public/customer surface
- updates demo docs and `serve:demo` so the backoffice app is part of the live ecosystem walkthrough

## Why

`web-app` now demonstrates customer self-service. This PR provides the contrasting internal consumer experience that proves the same published contracts and generated SDKs can support broader operational workflows for authorised internal roles.

## Demo Notes

- `support` can browse internal users and inspect user-scoped payment history
- `admin` can do the same, plus access the global payments queue
- auth/session setup stays at the app boundary, not inside page components
- internal pages use the generated SDKs against runtime-configured base URLs

## Testing

- `npm run nx -- build backoffice-app`