### PR TITLE
feat(mobile-app): add customer self-service mobile demo flows

### DIFF
--- a/apps/mobile-app/App.tsx
+++ b/apps/mobile-app/App.tsx
@@ -1,90 +1,227 @@
+import { useEffect, useState } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
-import {
-  mobileAuthServiceBaseUrl,
-  mobilePaymentsServiceBaseUrl,
-  mobileRuntimeWarnings,
-  mobileUsersServiceBaseUrl,
-} from './runtime';
+import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { AuthSessionProvider, useAuthSession } from './src/auth/AuthSessionContext';
+import MyPaymentsScreen from './src/screens/MyPaymentsScreen';
+import MyProfileScreen from './src/screens/MyProfileScreen';
+import SessionGateScreen from './src/screens/SessionGateScreen';
+import { queryClient } from './src/query-client';
+
+type AppScreen = 'profile' | 'payments';
+
+const screens: Array<{ id: AppScreen; label: string }> = [
+  { id: 'profile', label: 'My Profile' },
+  { id: 'payments', label: 'My Payments' },
+];
+
+function MobileCustomerShell() {
+  const { isAuthenticated, isCustomer, signOut, user } = useAuthSession();
+  const [activeScreen, setActiveScreen] = useState<AppScreen>('profile');
+
+  useEffect(() => {
+    if (isCustomer) {
+      setActiveScreen('profile');
+    }
+  }, [isCustomer, user?.id]);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar style="dark" />
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.heroCard}>
+          <Text style={styles.eyebrow}>genxapi ecosystem</Text>
+          <Text style={styles.title}>Customer Self-Service Mobile Demo</Text>
+          <Text style={styles.subtitle}>
+            `mobile-app` now acts as the second customer consumer, reusing the same runtime-configured
+            generated SDK boundary as `web-app`.
+          </Text>
+        </View>
+
+        <View style={styles.sessionCard}>
+          <View style={styles.sessionHeader}>
+            <View style={styles.sessionCopy}>
+              <Text style={styles.sectionEyebrow}>Demo Session</Text>
+              <Text style={styles.sessionTitle}>
+                {isAuthenticated && user && isCustomer ? user.name : 'Choose a seeded customer persona'}
+              </Text>
+              <Text style={styles.sessionSubtitle}>
+                {isAuthenticated && user && isCustomer
+                  ? 'This session unlocks only My Profile and My Payments, both backed by /me routes.'
+                  : 'The mobile demo keeps auth explicit and lightweight: one tap signs into auth-service with a customer account.'}
+              </Text>
+            </View>
+            {isAuthenticated && user && isCustomer ? (
+              <View style={styles.sessionMeta}>
+                <View style={styles.customerBadge}>
+                  <Text style={styles.customerBadgeText}>Customer</Text>
+                </View>
+                <Text style={styles.sessionEmail}>{user.email}</Text>
+                <Pressable onPress={signOut} style={styles.secondaryButton}>
+                  <Text style={styles.secondaryButtonText}>Sign out</Text>
+                </Pressable>
+              </View>
+            ) : null}
+          </View>
+        </View>
+
+        {isCustomer ? (
+          <>
+            <View style={styles.tabBar}>
+              {screens.map((screen) => {
+                const isActive = activeScreen === screen.id;
+
+                return (
+                  <Pressable
+                    key={screen.id}
+                    onPress={() => setActiveScreen(screen.id)}
+                    style={[styles.tabButton, isActive ? styles.tabButtonActive : null]}
+                  >
+                    <Text style={[styles.tabButtonText, isActive ? styles.tabButtonTextActive : null]}>
+                      {screen.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+
+            {activeScreen === 'profile' ? <MyProfileScreen /> : <MyPaymentsScreen />}
+          </>
+        ) : (
+          <SessionGateScreen />
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
 
 export default function App() {
   return (
-    <View style={styles.container}>
-      <Text style={styles.eyebrow}>genxapi ecosystem</Text>
-      <Text style={styles.title}>Mobile App</Text>
-      <Text style={styles.subtitle}>Auth-service and SDK bootstrap preview.</Text>
-      <View style={styles.card}>
-        <Text style={styles.label}>Auth service base URL</Text>
-        <Text style={styles.value}>{mobileAuthServiceBaseUrl || 'Not configured yet'}</Text>
-        <Text style={styles.label}>Users SDK base URL</Text>
-        <Text style={styles.value}>{mobileUsersServiceBaseUrl || 'Not configured yet'}</Text>
-        <Text style={styles.label}>Payments SDK base URL</Text>
-        <Text style={styles.value}>
-          {mobilePaymentsServiceBaseUrl || 'Not configured yet'}
-        </Text>
-        {mobileRuntimeWarnings.map((warning) => (
-          <Text key={warning} style={styles.warning}>
-            {warning}
-          </Text>
-        ))}
-      </View>
-      <StatusBar style="dark" />
-    </View>
+    <QueryClientProvider client={queryClient}>
+      <AuthSessionProvider>
+        <MobileCustomerShell />
+      </AuthSessionProvider>
+    </QueryClientProvider>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  safeArea: {
     flex: 1,
-    backgroundColor: '#f8fafc',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 24
+    backgroundColor: '#f5efe6',
+  },
+  content: {
+    paddingHorizontal: 20,
+    paddingVertical: 18,
+    gap: 16,
+  },
+  heroCard: {
+    borderRadius: 28,
+    padding: 24,
+    backgroundColor: '#123524',
   },
   eyebrow: {
+    color: '#d4f2d2',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.6,
+    marginBottom: 12,
     textTransform: 'uppercase',
-    letterSpacing: 2,
-    fontSize: 12,
-    color: '#64748b',
-    marginBottom: 12
   },
   title: {
-    fontSize: 32,
-    fontWeight: '700',
-    color: '#0f172a'
+    color: '#f8fbf6',
+    fontSize: 30,
+    fontWeight: '800',
+    lineHeight: 36,
   },
   subtitle: {
+    color: '#c3ddc9',
+    fontSize: 15,
+    lineHeight: 22,
     marginTop: 12,
-    fontSize: 16,
-    color: '#475569'
   },
-  card: {
-    width: '100%',
-    marginTop: 24,
-    borderRadius: 16,
-    backgroundColor: '#ffffff',
+  sessionCard: {
+    backgroundColor: '#fffaf3',
+    borderColor: '#d9d2c3',
+    borderRadius: 24,
+    borderWidth: 1,
     padding: 20,
-    shadowColor: '#0f172a',
-    shadowOpacity: 0.08,
-    shadowRadius: 20,
-    shadowOffset: { width: 0, height: 10 },
-    elevation: 4
   },
-  label: {
-    marginTop: 8,
-    fontSize: 12,
-    letterSpacing: 1,
+  sessionHeader: {
+    gap: 16,
+  },
+  sessionCopy: {
+    gap: 8,
+  },
+  sectionEyebrow: {
+    color: '#7b6b4f',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
     textTransform: 'uppercase',
-    color: '#64748b'
   },
-  value: {
-    marginTop: 4,
-    fontSize: 16,
-    color: '#0f172a'
+  sessionTitle: {
+    color: '#1d2a22',
+    fontSize: 20,
+    fontWeight: '700',
   },
-  warning: {
-    marginTop: 12,
-    color: '#b91c1c',
-    fontSize: 14
-  }
+  sessionSubtitle: {
+    color: '#5d665f',
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  sessionMeta: {
+    alignItems: 'flex-start',
+    gap: 10,
+  },
+  customerBadge: {
+    backgroundColor: '#d9f3d7',
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  customerBadgeText: {
+    color: '#245b30',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  sessionEmail: {
+    color: '#405046',
+    fontSize: 14,
+  },
+  secondaryButton: {
+    backgroundColor: '#eff1eb',
+    borderRadius: 999,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  secondaryButtonText: {
+    color: '#233127',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  tabBar: {
+    backgroundColor: '#e4ddcf',
+    borderRadius: 20,
+    flexDirection: 'row',
+    padding: 4,
+  },
+  tabButton: {
+    alignItems: 'center',
+    borderRadius: 16,
+    flex: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 14,
+  },
+  tabButtonActive: {
+    backgroundColor: '#ffffff',
+  },
+  tabButtonText: {
+    color: '#675a45',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  tabButtonTextActive: {
+    color: '#133923',
+  },
 });

--- a/apps/mobile-app/runtime.ts
+++ b/apps/mobile-app/runtime.ts
@@ -2,7 +2,7 @@ import { createAuthClient } from '@genxapi/ecosystem-auth-client';
 import { createUsersSdk } from '@genxapi/ecosystem-users-sdk';
 import { createPaymentsSdk } from 'genxapi-ecosystem-payments-sdk';
 
-type AccessTokenProvider =
+export type MobileAccessTokenProvider =
   | string
   | null
   | undefined
@@ -24,7 +24,7 @@ export const mobileAuthClient = createAuthClient({
   baseUrl: mobileAuthServiceBaseUrl,
 });
 
-export const createMobileSdks = (accessToken: AccessTokenProvider) => ({
+export const createMobileSdks = (accessToken: MobileAccessTokenProvider) => ({
   users: createUsersSdk({
     baseUrl: mobileUsersServiceBaseUrl,
     accessToken,
@@ -42,3 +42,5 @@ export const mobileRuntimeWarnings = [
     ? 'Set EXPO_PUBLIC_PAYMENTS_SERVICE_BASE_URL for payments-service.'
     : '',
 ].filter(Boolean);
+
+export const isMobileRuntimeReady = mobileRuntimeWarnings.length === 0;

--- a/apps/mobile-app/src/api/sdk.ts
+++ b/apps/mobile-app/src/api/sdk.ts
@@ -1,0 +1,24 @@
+import { users } from '@genxapi/ecosystem-users-sdk';
+import { payments } from 'genxapi-ecosystem-payments-sdk';
+import { createMobileSdks, type MobileAccessTokenProvider } from '../../runtime';
+import { useAuthSession } from '../auth/AuthSessionContext';
+
+const withSignal = (signal?: AbortSignal): RequestInit | undefined => (signal ? { signal } : undefined);
+
+export type CustomerProfile = users.User;
+export type CustomerPayment = payments.Payment;
+
+export const createCustomerMobileApi = (accessToken: MobileAccessTokenProvider) => {
+  const sdks = createMobileSdks(accessToken);
+
+  return {
+    getMyProfile: (signal?: AbortSignal) => sdks.users.getMe(withSignal(signal)),
+    getMyPayments: (signal?: AbortSignal) => sdks.payments.getMyPayments(withSignal(signal)),
+  };
+};
+
+export const useCustomerMobileApi = () => {
+  const { accessToken } = useAuthSession();
+
+  return createCustomerMobileApi(accessToken);
+};

--- a/apps/mobile-app/src/auth/AuthSessionContext.tsx
+++ b/apps/mobile-app/src/auth/AuthSessionContext.tsx
@@ -1,0 +1,92 @@
+import type { LoginCredentials } from '@genxapi/ecosystem-auth-client';
+import {
+  createContext,
+  useContext,
+  useState,
+  type PropsWithChildren,
+} from 'react';
+import { isMobileRuntimeReady, mobileAuthClient } from '../../runtime';
+import { queryClient } from '../query-client';
+import { getErrorMessage } from '../utils/format';
+import { demoPersonas, type DemoPersona } from './demo-personas';
+import { toAuthSessionState, type AuthSessionState } from './auth-session';
+
+interface AuthSessionContextValue extends AuthSessionState {
+  isPending: boolean;
+  error: string | null;
+  demoPersonas: DemoPersona[];
+  signInAsDemoPersona: (personaId: DemoPersona['id']) => Promise<boolean>;
+  signOut: () => void;
+}
+
+const AuthSessionContext = createContext<AuthSessionContextValue | null>(null);
+
+export const AuthSessionProvider = ({ children }: PropsWithChildren) => {
+  const [session, setSession] = useState(() => toAuthSessionState(null));
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loginWithCredentials = async (credentials: LoginCredentials) => {
+    if (!isMobileRuntimeReady) {
+      setError('Set all EXPO_PUBLIC_* service URLs before starting a demo session.');
+      return false;
+    }
+
+    setIsPending(true);
+    setError(null);
+
+    try {
+      const nextSession = await mobileAuthClient.login(credentials);
+
+      if (nextSession.user.role !== 'customer') {
+        throw new Error('This mobile demo only supports customer personas.');
+      }
+
+      queryClient.clear();
+      setSession(toAuthSessionState(nextSession));
+      return true;
+    } catch (nextError) {
+      setError(getErrorMessage(nextError));
+      return false;
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const value: AuthSessionContextValue = {
+    ...session,
+    isPending,
+    error,
+    demoPersonas,
+    signInAsDemoPersona: async (personaId) => {
+      const persona = demoPersonas.find((entry) => entry.id === personaId);
+
+      if (!persona) {
+        setError('Unknown demo persona.');
+        return false;
+      }
+
+      return loginWithCredentials({
+        email: persona.email,
+        password: persona.password,
+      });
+    },
+    signOut: () => {
+      queryClient.clear();
+      setError(null);
+      setSession(toAuthSessionState(null));
+    },
+  };
+
+  return <AuthSessionContext.Provider value={value}>{children}</AuthSessionContext.Provider>;
+};
+
+export const useAuthSession = () => {
+  const context = useContext(AuthSessionContext);
+
+  if (!context) {
+    throw new Error('useAuthSession must be used within AuthSessionProvider.');
+  }
+
+  return context;
+};

--- a/apps/mobile-app/src/auth/auth-session.ts
+++ b/apps/mobile-app/src/auth/auth-session.ts
@@ -1,0 +1,17 @@
+import type { AuthSession } from '@genxapi/ecosystem-auth-client';
+
+export interface AuthSessionState {
+  session: AuthSession | null;
+  user: AuthSession['user'] | null;
+  accessToken: string | null;
+  isAuthenticated: boolean;
+  isCustomer: boolean;
+}
+
+export const toAuthSessionState = (session: AuthSession | null): AuthSessionState => ({
+  session,
+  user: session?.user ?? null,
+  accessToken: session?.accessToken ?? null,
+  isAuthenticated: session !== null,
+  isCustomer: session?.user.role === 'customer',
+});

--- a/apps/mobile-app/src/auth/demo-personas.ts
+++ b/apps/mobile-app/src/auth/demo-personas.ts
@@ -1,0 +1,27 @@
+import type { LoginCredentials } from '@genxapi/ecosystem-auth-client';
+
+export interface DemoPersona extends LoginCredentials {
+  id: 'bob-smith' | 'ethan-williams';
+  name: string;
+  role: 'customer';
+  description: string;
+}
+
+export const demoPersonas: DemoPersona[] = [
+  {
+    id: 'bob-smith',
+    name: 'Bob Smith',
+    role: 'customer',
+    email: 'bob.smith@example.com',
+    password: 'bob-demo-password',
+    description: 'Customer account with two payment records, including a refund.',
+  },
+  {
+    id: 'ethan-williams',
+    name: 'Ethan Williams',
+    role: 'customer',
+    email: 'ethan.williams@example.com',
+    password: 'ethan-demo-password',
+    description: 'Customer account with a single completed payment.',
+  },
+];

--- a/apps/mobile-app/src/query-client.ts
+++ b/apps/mobile-app/src/query-client.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/apps/mobile-app/src/screens/MyPaymentsScreen.tsx
+++ b/apps/mobile-app/src/screens/MyPaymentsScreen.tsx
@@ -1,0 +1,336 @@
+import { useQuery } from '@tanstack/react-query';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { type CustomerPayment, useCustomerMobileApi } from '../api/sdk';
+import { useAuthSession } from '../auth/AuthSessionContext';
+import {
+  formatCurrency,
+  formatDateTime,
+  formatLabel,
+  getErrorMessage,
+} from '../utils/format';
+
+const getStatusTone = (status: CustomerPayment['status']) => {
+  switch (status) {
+    case 'completed':
+      return {
+        badge: styles.statusBadgeCompleted,
+        text: styles.statusBadgeTextCompleted,
+      };
+    case 'failed':
+      return {
+        badge: styles.statusBadgeFailed,
+        text: styles.statusBadgeTextFailed,
+      };
+    case 'refunded':
+      return {
+        badge: styles.statusBadgeRefunded,
+        text: styles.statusBadgeTextRefunded,
+      };
+    case 'pending':
+    default:
+      return {
+        badge: styles.statusBadgePending,
+        text: styles.statusBadgeTextPending,
+      };
+  }
+};
+
+export default function MyPaymentsScreen() {
+  const api = useCustomerMobileApi();
+  const { user } = useAuthSession();
+  const paymentsQuery = useQuery({
+    queryKey: ['me', user?.id ?? 'anonymous', 'payments'],
+    queryFn: ({ signal }) => api.getMyPayments(signal),
+    enabled: Boolean(user),
+  });
+
+  const payments = [...(paymentsQuery.data ?? [])].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+  const totalAmount = payments.reduce((sum, payment) => sum + payment.amount, 0);
+  const currency = payments[0]?.currency ?? 'USD';
+  const completedCount = payments.filter((payment) => payment.status === 'completed').length;
+  const refundedCount = payments.filter((payment) => payment.status === 'refunded').length;
+  const latestPayment = payments[0] ?? null;
+
+  return (
+    <View style={styles.screen}>
+      <View style={styles.heroCard}>
+        <Text style={styles.eyebrow}>My Payments</Text>
+        <Text style={styles.title}>Your payment history</Text>
+        <Text style={styles.description}>
+          This screen uses the generated payments SDK against /me/payments, so every record shown
+          belongs to the authenticated customer.
+        </Text>
+      </View>
+
+      {paymentsQuery.isLoading ? (
+        <View style={styles.card}>
+          <ActivityIndicator color="#123524" />
+          <Text style={styles.stateText}>Loading your payments...</Text>
+        </View>
+      ) : null}
+
+      {paymentsQuery.isError ? (
+        <View style={styles.card}>
+          <Text style={styles.errorText}>Error: {getErrorMessage(paymentsQuery.error)}</Text>
+          <Pressable onPress={() => void paymentsQuery.refetch()} style={styles.secondaryButton}>
+            <Text style={styles.secondaryButtonText}>Try again</Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      {!paymentsQuery.isLoading && !paymentsQuery.isError ? (
+        <>
+          <View style={styles.summaryGrid}>
+            <View style={styles.summaryCard}>
+              <Text style={styles.summaryLabel}>Payment records</Text>
+              <Text style={styles.summaryValue}>{payments.length}</Text>
+              <Text style={styles.summaryDescription}>Only your customer activity is shown here.</Text>
+            </View>
+            <View style={styles.summaryCard}>
+              <Text style={styles.summaryLabel}>Total amount</Text>
+              <Text style={styles.summaryValue}>{formatCurrency(totalAmount, currency)}</Text>
+              <Text style={styles.summaryDescription}>Sum of the payments returned for this session.</Text>
+            </View>
+            <View style={styles.summaryCard}>
+              <Text style={styles.summaryLabel}>Completed</Text>
+              <Text style={styles.summaryValue}>{completedCount}</Text>
+              <Text style={styles.summaryDescription}>Successful charges on your account.</Text>
+            </View>
+            <View style={styles.summaryCard}>
+              <Text style={styles.summaryLabel}>Latest activity</Text>
+              <Text style={styles.summaryValue}>
+                {latestPayment ? formatLabel(latestPayment.status) : 'No activity'}
+              </Text>
+              <Text style={styles.summaryDescription}>
+                {latestPayment ? formatDateTime(latestPayment.createdAt) : 'No payments found yet.'}
+              </Text>
+            </View>
+          </View>
+
+          {payments.length === 0 ? (
+            <View style={styles.card}>
+              <Text style={styles.cardTitle}>No payments yet</Text>
+              <Text style={styles.stateText}>
+                This customer account does not have any payment history in the demo dataset.
+              </Text>
+            </View>
+          ) : (
+            <View style={styles.card}>
+              <Text style={styles.cardTitle}>Payment activity</Text>
+              <Text style={styles.cardDescription}>
+                Refunded payments: {refundedCount}. The app does not expose the internal all-payments queue.
+              </Text>
+              <View style={styles.paymentList}>
+                {payments.map((payment) => {
+                  const statusTone = getStatusTone(payment.status);
+
+                  return (
+                    <View key={payment.id} style={styles.paymentCard}>
+                      <View style={styles.paymentHeader}>
+                        <View>
+                          <Text style={styles.amountText}>
+                            {formatCurrency(payment.amount, payment.currency)}
+                          </Text>
+                          <Text style={styles.dateText}>{formatDateTime(payment.createdAt)}</Text>
+                        </View>
+                        <View style={[styles.statusBadge, statusTone.badge]}>
+                          <Text style={[styles.statusBadgeText, statusTone.text]}>
+                            {formatLabel(payment.status)}
+                          </Text>
+                        </View>
+                      </View>
+                      <View style={styles.metaRow}>
+                        <Text style={styles.metaLabel}>Method</Text>
+                        <Text style={styles.metaValue}>{formatLabel(payment.method)}</Text>
+                      </View>
+                      <View style={styles.metaRow}>
+                        <Text style={styles.metaLabel}>Transaction</Text>
+                        <Text style={styles.metaValue}>{payment.transactionId}</Text>
+                      </View>
+                    </View>
+                  );
+                })}
+              </View>
+            </View>
+          )}
+        </>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    gap: 16,
+  },
+  heroCard: {
+    backgroundColor: '#edf6f7',
+    borderColor: '#c6d9de',
+    borderRadius: 24,
+    borderWidth: 1,
+    padding: 20,
+  },
+  eyebrow: {
+    color: '#2a6d7d',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    marginBottom: 10,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: '#1d2a22',
+    fontSize: 24,
+    fontWeight: '700',
+  },
+  description: {
+    color: '#5d665f',
+    fontSize: 15,
+    lineHeight: 22,
+    marginTop: 10,
+  },
+  card: {
+    backgroundColor: '#fffaf3',
+    borderColor: '#d9d2c3',
+    borderRadius: 24,
+    borderWidth: 1,
+    gap: 14,
+    padding: 20,
+  },
+  stateText: {
+    color: '#405046',
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  errorText: {
+    color: '#a11d1d',
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  secondaryButton: {
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    backgroundColor: '#eff1eb',
+    borderRadius: 18,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  secondaryButtonText: {
+    color: '#233127',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  summaryGrid: {
+    gap: 12,
+  },
+  summaryCard: {
+    backgroundColor: '#fffaf3',
+    borderColor: '#d9d2c3',
+    borderRadius: 24,
+    borderWidth: 1,
+    padding: 18,
+  },
+  summaryLabel: {
+    color: '#7b6b4f',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    marginBottom: 6,
+    textTransform: 'uppercase',
+  },
+  summaryValue: {
+    color: '#1d2a22',
+    fontSize: 22,
+    fontWeight: '700',
+  },
+  summaryDescription: {
+    color: '#5d665f',
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 8,
+  },
+  cardTitle: {
+    color: '#1d2a22',
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  cardDescription: {
+    color: '#5d665f',
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  paymentList: {
+    gap: 14,
+  },
+  paymentCard: {
+    backgroundColor: '#f6f0e4',
+    borderRadius: 20,
+    gap: 12,
+    padding: 16,
+  },
+  paymentHeader: {
+    alignItems: 'flex-start',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  amountText: {
+    color: '#1d2a22',
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  dateText: {
+    color: '#5d665f',
+    fontSize: 13,
+    marginTop: 6,
+  },
+  statusBadge: {
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  statusBadgeCompleted: {
+    backgroundColor: '#d9f3d7',
+  },
+  statusBadgePending: {
+    backgroundColor: '#feefc3',
+  },
+  statusBadgeRefunded: {
+    backgroundColor: '#ecdfff',
+  },
+  statusBadgeFailed: {
+    backgroundColor: '#fde2df',
+  },
+  statusBadgeText: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  statusBadgeTextCompleted: {
+    color: '#245b30',
+  },
+  statusBadgeTextPending: {
+    color: '#8a5a00',
+  },
+  statusBadgeTextRefunded: {
+    color: '#5c2ca6',
+  },
+  statusBadgeTextFailed: {
+    color: '#9e1c1c',
+  },
+  metaRow: {
+    gap: 4,
+  },
+  metaLabel: {
+    color: '#7b6b4f',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  metaValue: {
+    color: '#1d2a22',
+    fontSize: 15,
+    lineHeight: 20,
+  },
+});

--- a/apps/mobile-app/src/screens/MyProfileScreen.tsx
+++ b/apps/mobile-app/src/screens/MyProfileScreen.tsx
@@ -1,0 +1,266 @@
+import { useQuery } from '@tanstack/react-query';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useCustomerMobileApi } from '../api/sdk';
+import { useAuthSession } from '../auth/AuthSessionContext';
+import { formatDateTime, formatLabel, getErrorMessage } from '../utils/format';
+
+export default function MyProfileScreen() {
+  const api = useCustomerMobileApi();
+  const { user } = useAuthSession();
+  const profileQuery = useQuery({
+    queryKey: ['me', user?.id ?? 'anonymous'],
+    queryFn: ({ signal }) => api.getMyProfile(signal),
+    enabled: Boolean(user),
+  });
+
+  return (
+    <View style={styles.screen}>
+      <View style={styles.heroCard}>
+        <Text style={styles.eyebrow}>My Profile</Text>
+        <Text style={styles.title}>
+          {profileQuery.data ? `Welcome back, ${profileQuery.data.firstName}.` : 'Your account at a glance'}
+        </Text>
+        <Text style={styles.description}>
+          This screen reads the authenticated customer record from /me through the generated users SDK.
+          There is no cross-user navigation in the mobile app.
+        </Text>
+      </View>
+
+      {profileQuery.isLoading ? (
+        <View style={styles.card}>
+          <ActivityIndicator color="#123524" />
+          <Text style={styles.stateText}>Loading your profile...</Text>
+        </View>
+      ) : null}
+
+      {profileQuery.isError ? (
+        <View style={styles.card}>
+          <Text style={styles.errorText}>Error: {getErrorMessage(profileQuery.error)}</Text>
+          <Pressable onPress={() => void profileQuery.refetch()} style={styles.secondaryButton}>
+            <Text style={styles.secondaryButtonText}>Try again</Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      {!profileQuery.isLoading && !profileQuery.isError && profileQuery.data ? (
+        <>
+          <View style={styles.card}>
+            <View style={styles.cardHeader}>
+              <Text style={styles.cardTitle}>Account details</Text>
+              <View style={styles.badge}>
+                <Text style={styles.badgeText}>{formatLabel(profileQuery.data.role)}</Text>
+              </View>
+            </View>
+
+            <View style={styles.detailList}>
+              <View style={styles.detailRow}>
+                <Text style={styles.detailLabel}>Full name</Text>
+                <Text style={styles.detailValue}>
+                  {profileQuery.data.firstName} {profileQuery.data.lastName}
+                </Text>
+              </View>
+              <View style={styles.detailRow}>
+                <Text style={styles.detailLabel}>Email</Text>
+                <Text style={styles.detailValue}>{profileQuery.data.email}</Text>
+              </View>
+              <View style={styles.detailRow}>
+                <Text style={styles.detailLabel}>Status</Text>
+                <View
+                  style={[
+                    styles.badge,
+                    profileQuery.data.isActive ? styles.successBadge : styles.inactiveBadge,
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.badgeText,
+                      profileQuery.data.isActive ? styles.successBadgeText : styles.inactiveBadgeText,
+                    ]}
+                  >
+                    {profileQuery.data.isActive ? 'Active' : 'Inactive'}
+                  </Text>
+                </View>
+              </View>
+              <View style={styles.detailRow}>
+                <Text style={styles.detailLabel}>Member since</Text>
+                <Text style={styles.detailValue}>{formatDateTime(profileQuery.data.createdAt)}</Text>
+              </View>
+              <View style={styles.detailRow}>
+                <Text style={styles.detailLabel}>Customer id</Text>
+                <Text style={styles.detailValue}>User {profileQuery.data.id}</Text>
+              </View>
+            </View>
+          </View>
+
+          <View style={styles.card}>
+            <Text style={styles.cardTitle}>Session scope</Text>
+            <View style={styles.summaryStack}>
+              <View style={styles.summaryBlock}>
+                <Text style={styles.summaryLabel}>Authenticated claims</Text>
+                <Text style={styles.summaryValue}>{user?.name ?? profileQuery.data.firstName}</Text>
+                <Text style={styles.summaryDescription}>
+                  Demo session claims decide whether the customer screens are visible.
+                </Text>
+              </View>
+              <View style={styles.summaryBlock}>
+                <Text style={styles.summaryLabel}>Visible screens</Text>
+                <Text style={styles.summaryValue}>My Profile and My Payments</Text>
+                <Text style={styles.summaryDescription}>
+                  Internal browsing flows are intentionally absent from this mobile customer app.
+                </Text>
+              </View>
+              <View style={styles.summaryBlock}>
+                <Text style={styles.summaryLabel}>Runtime adoption</Text>
+                <Text style={styles.summaryValue}>Generated SDK + app session</Text>
+                <Text style={styles.summaryDescription}>
+                  Base URLs and bearer token injection stay at the app boundary instead of inside the screen.
+                </Text>
+              </View>
+            </View>
+          </View>
+        </>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    gap: 16,
+  },
+  heroCard: {
+    backgroundColor: '#fef6e8',
+    borderColor: '#ead9b8',
+    borderRadius: 24,
+    borderWidth: 1,
+    padding: 20,
+  },
+  eyebrow: {
+    color: '#956f16',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    marginBottom: 10,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: '#1d2a22',
+    fontSize: 24,
+    fontWeight: '700',
+  },
+  description: {
+    color: '#5d665f',
+    fontSize: 15,
+    lineHeight: 22,
+    marginTop: 10,
+  },
+  card: {
+    backgroundColor: '#fffaf3',
+    borderColor: '#d9d2c3',
+    borderRadius: 24,
+    borderWidth: 1,
+    gap: 14,
+    padding: 20,
+  },
+  stateText: {
+    color: '#405046',
+    fontSize: 15,
+  },
+  errorText: {
+    color: '#a11d1d',
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  secondaryButton: {
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    backgroundColor: '#eff1eb',
+    borderRadius: 18,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  secondaryButtonText: {
+    color: '#233127',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  cardHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  cardTitle: {
+    color: '#1d2a22',
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  badge: {
+    backgroundColor: '#d9f3d7',
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  badgeText: {
+    color: '#245b30',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  successBadge: {
+    backgroundColor: '#d9f3d7',
+  },
+  successBadgeText: {
+    color: '#245b30',
+  },
+  inactiveBadge: {
+    backgroundColor: '#ece7df',
+  },
+  inactiveBadgeText: {
+    color: '#6d6558',
+  },
+  detailList: {
+    gap: 16,
+  },
+  detailRow: {
+    gap: 8,
+  },
+  detailLabel: {
+    color: '#7b6b4f',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  detailValue: {
+    color: '#1d2a22',
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  summaryStack: {
+    gap: 14,
+    marginTop: 14,
+  },
+  summaryBlock: {
+    backgroundColor: '#f6f0e4',
+    borderRadius: 20,
+    padding: 16,
+  },
+  summaryLabel: {
+    color: '#7b6b4f',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    marginBottom: 6,
+    textTransform: 'uppercase',
+  },
+  summaryValue: {
+    color: '#1d2a22',
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  summaryDescription: {
+    color: '#5d665f',
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 8,
+  },
+});

--- a/apps/mobile-app/src/screens/SessionGateScreen.tsx
+++ b/apps/mobile-app/src/screens/SessionGateScreen.tsx
@@ -1,0 +1,241 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import {
+  isMobileRuntimeReady,
+  mobileAuthServiceBaseUrl,
+  mobilePaymentsServiceBaseUrl,
+  mobileRuntimeWarnings,
+  mobileUsersServiceBaseUrl,
+} from '../../runtime';
+import { useAuthSession } from '../auth/AuthSessionContext';
+
+const runtimeRows = [
+  {
+    label: 'Auth service',
+    value: mobileAuthServiceBaseUrl,
+  },
+  {
+    label: 'Users SDK base URL',
+    value: mobileUsersServiceBaseUrl,
+  },
+  {
+    label: 'Payments SDK base URL',
+    value: mobilePaymentsServiceBaseUrl,
+  },
+];
+
+export default function SessionGateScreen() {
+  const { demoPersonas, error, isAuthenticated, isCustomer, isPending, signInAsDemoPersona, signOut, user } =
+    useAuthSession();
+
+  const title =
+    isAuthenticated && !isCustomer ? 'Switch to a customer demo persona' : 'Choose a customer demo session';
+  const description =
+    isAuthenticated && !isCustomer
+      ? 'This mobile app is intentionally scoped to customer self-service. Internal support and admin flows stay in backoffice-app.'
+      : 'Each persona signs into auth-service, then the app loads only /me and /me/payments through the generated SDK layer.';
+
+  return (
+    <View style={styles.screen}>
+      <View style={styles.card}>
+        <Text style={styles.eyebrow}>Customer Access</Text>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.description}>{description}</Text>
+        {isAuthenticated && user && !isCustomer ? (
+          <Text style={styles.errorText}>
+            Current session: {user.name} ({user.role}). Switch back to a customer persona to continue.
+          </Text>
+        ) : null}
+      </View>
+
+      {demoPersonas.map((persona) => (
+        <View key={persona.id} style={styles.card}>
+          <View style={styles.personaHeader}>
+            <View style={styles.personaCopy}>
+              <Text style={styles.personaLabel}>Demo persona</Text>
+              <Text style={styles.personaName}>{persona.name}</Text>
+              <Text style={styles.personaEmail}>{persona.email}</Text>
+            </View>
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>{persona.role}</Text>
+            </View>
+          </View>
+          <Text style={styles.personaDescription}>{persona.description}</Text>
+          <Pressable
+            disabled={!isMobileRuntimeReady || isPending}
+            onPress={() => {
+              void signInAsDemoPersona(persona.id);
+            }}
+            style={[
+              styles.primaryButton,
+              !isMobileRuntimeReady || isPending ? styles.disabledButton : null,
+            ]}
+          >
+            <Text style={styles.primaryButtonText}>
+              {isPending ? 'Starting session...' : `Use ${persona.name}`}
+            </Text>
+          </Pressable>
+        </View>
+      ))}
+
+      <View style={styles.card}>
+        <Text style={styles.title}>Demo notes</Text>
+        <View style={styles.stack}>
+          {runtimeRows.map((row) => (
+            <View key={row.label}>
+              <Text style={styles.runtimeLabel}>{row.label}</Text>
+              <Text style={styles.runtimeValue}>{row.value || 'Not configured'}</Text>
+            </View>
+          ))}
+          {!isMobileRuntimeReady ? (
+            <Text style={styles.warningText}>
+              Persona buttons stay disabled until all three EXPO_PUBLIC_* service URLs are set.
+            </Text>
+          ) : null}
+          {mobileRuntimeWarnings.map((warning) => (
+            <Text key={warning} style={styles.warningText}>
+              {warning}
+            </Text>
+          ))}
+          {error ? <Text style={styles.errorText}>Error: {error}</Text> : null}
+          {isAuthenticated ? (
+            <Pressable onPress={signOut} style={styles.secondaryButton}>
+              <Text style={styles.secondaryButtonText}>Clear current session</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    gap: 16,
+  },
+  card: {
+    backgroundColor: '#fffaf3',
+    borderColor: '#d9d2c3',
+    borderRadius: 24,
+    borderWidth: 1,
+    padding: 20,
+  },
+  eyebrow: {
+    color: '#7b6b4f',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    marginBottom: 10,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: '#1d2a22',
+    fontSize: 22,
+    fontWeight: '700',
+  },
+  description: {
+    color: '#5d665f',
+    fontSize: 15,
+    lineHeight: 22,
+    marginTop: 10,
+  },
+  personaHeader: {
+    alignItems: 'flex-start',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  personaCopy: {
+    flex: 1,
+    gap: 6,
+  },
+  personaLabel: {
+    color: '#7b6b4f',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  personaName: {
+    color: '#1d2a22',
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  personaEmail: {
+    color: '#4b5a51',
+    fontSize: 14,
+  },
+  personaDescription: {
+    color: '#5d665f',
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 14,
+    marginBottom: 18,
+  },
+  badge: {
+    backgroundColor: '#d9f3d7',
+    borderRadius: 999,
+    marginLeft: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  badgeText: {
+    color: '#245b30',
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'capitalize',
+  },
+  primaryButton: {
+    alignItems: 'center',
+    backgroundColor: '#123524',
+    borderRadius: 18,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  primaryButtonText: {
+    color: '#f8fbf6',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  disabledButton: {
+    opacity: 0.45,
+  },
+  stack: {
+    gap: 14,
+    marginTop: 16,
+  },
+  runtimeLabel: {
+    color: '#7b6b4f',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    marginBottom: 4,
+    textTransform: 'uppercase',
+  },
+  runtimeValue: {
+    color: '#1d2a22',
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  warningText: {
+    color: '#8b3d19',
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  errorText: {
+    color: '#a11d1d',
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 12,
+  },
+  secondaryButton: {
+    alignItems: 'center',
+    backgroundColor: '#eff1eb',
+    borderRadius: 18,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  secondaryButtonText: {
+    color: '#233127',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+});

--- a/apps/mobile-app/src/utils/format.ts
+++ b/apps/mobile-app/src/utils/format.ts
@@ -1,0 +1,46 @@
+export const formatDateTime = (value?: string | number): string => {
+  if (value === undefined || value === null) {
+    return '-';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return '-';
+  }
+
+  return date.toLocaleString();
+};
+
+export const formatCurrency = (amount: number, currency = 'USD'): string => {
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+    }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+};
+
+export const formatLabel = (value?: string): string => {
+  if (!value) {
+    return '-';
+  }
+
+  return value
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+};
+
+export const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  return 'Something went wrong.';
+};


### PR DESCRIPTION
This PR implements turning `mobile-app` into the second customer-facing consumer in the ecosystem demo.

`mobile-app` now mirrors the same customer self-service model already established in `web-app`: it boots a demo customer session against `auth-service`, consumes the runtime-configured generated SDKs, and only loads the authenticated customer’s own profile and payments.

## What changed

- Replaced the Expo starter screen with a small customer-focused mobile app shell
- Added a lightweight demo session flow with seeded customer personas
- Centralised mobile SDK usage behind the existing runtime-configured app boundary
- Added a customer-only session gate with clear runtime, loading, and error states
- Added a `My Profile` screen backed by `GET /me`
- Added a `My Payments` screen backed by `GET /me/payments`
- Removed any admin/internal browsing behaviour from the mobile experience
- Kept navigation lightweight and driven by authenticated customer context rather than route params

## Implementation notes

- `mobile-app` now uses the generated SDK layer introduced in Phase 2
- Base URLs still come from `EXPO_PUBLIC_*` runtime config
- Bearer token injection is handled once at the app boundary, not inside screens
- The mobile session strategy is intentionally demo-friendly and not a production auth flow
- Session state is kept app-owned and lightweight for Expo/React Native compatibility

## Why this matters

This makes the ecosystem story clearer:

- `web-app` and `mobile-app` are customer self-service consumers
- `backoffice-app` is the internal operations consumer
- all of them consume service-owned contracts through generated SDKs
- customer access rules hold across platforms, not just in the browser

## Testing

- Ran `./node_modules/.bin/tsc --noEmit -p apps/mobile-app/tsconfig.json`

## Scope

- No backend auth expansion
- No `backoffice-app` changes
- No `web-app` rebuild or broader cross-repo refactor
