### PR TITLE
feat: align ecosystem branding and move demo packages to genxapi-labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # GenX API Ecosystem Demo
 
-This repository is a presentation-ready proof of the GenX API ecosystem inside an Nx monorepo.
+End-to-end proof of the GenX API open source ecosystem inside an Nx monorepo.
 
-It demonstrates one clear boundary:
+It shows the full handoff from service-owned contract publication to GenX API SDK generation to multi-consumer adoption:
 
 - backend services own Swagger and contract publication
-- GenX API starts from those published contracts
-- generated SDK packages remain independent deliverables
+- [GenX API](https://github.com/genxapi/genxapi) starts from those published contracts
+- generated SDK packages remain independent demo deliverables
 - consumer apps adopt the SDKs through normal package boundaries
 
 The demo now includes three services, three consumers, and role-aware JWT personas:
@@ -15,12 +15,23 @@ The demo now includes three services, three consumers, and role-aware JWT person
 - `mobile-app`: customer self-service in Expo / React Native
 - `backoffice-app`: internal operations for support and admin users
 
+## Open Source Ecosystem
+
+| Repository | Role in the ecosystem | Use it when |
+| --- | --- | --- |
+| [`genxapi`](https://github.com/genxapi/genxapi) | Core generator product and CLI for contract-driven SDK package generation | You want to generate SDKs locally, in custom CI, or through your own workflow orchestration |
+| [`genxapi-action`](https://github.com/genxapi/genxapi-action) | Official GitHub Actions adoption path for GenX API | Your team wants the GitHub-native wrapper around the GenX API CLI |
+| [`genxapi-ecosystem-demo`](https://github.com/genxapi/genxapi-ecosystem-demo) | End-to-end proof of contract publication, SDK generation, and multi-consumer adoption | You want to understand the full ecosystem story or run a conference-ready technical demo |
+
+This repository is the proof repo. It intentionally shows the lifecycle that the core product and the GitHub Action support elsewhere, without putting demo packages in the core `@genxapi/*` namespace.
+
 ## What This Repository Demonstrates
 
 - `auth-service`, `users-service`, and `payments-service` own their contracts and publish versioned snapshots under `docs/contracts/`
 - GenX API reads those published snapshots through `genxapi.users.config.json` and `genxapi.config.json`
 - `sdk/users-sdk` and `sdk/payments-sdk` are generated packages, not handwritten app clients
 - the customer apps and the backoffice app all adopt those SDKs explicitly
+- demo-local packages use the separate `@genxapi-labs/*` scope so they do not pollute the core `@genxapi/*` package surface
 - JWT claims decide which app flows are valid for each persona
 
 ## Ecosystem Flow
@@ -55,7 +66,7 @@ flowchart LR
 | `genxapi.config.json` | GenX API config for the payments SDK, pointed at the published payments contract |
 | `sdk/users-sdk` | Generated users SDK package consumed by apps |
 | `sdk/payments-sdk` | Generated payments SDK package consumed by apps |
-| `libs/auth-client` | Shared auth-service client helpers and session types |
+| `libs/auth-client` | Shared auth-service session helpers and types |
 | `apps/web-app` | Customer self-service browser app using `/me` and `/me/payments` |
 | `apps/mobile-app` | Second customer consumer using the same role-aware customer scope in Expo |
 | `apps/backoffice-app` | Internal support/admin app using `/users`, `/users/:id`, and admin-only `/payments` |
@@ -150,6 +161,7 @@ If you are testing on a physical device, replace `127.0.0.1` with your machine's
    Show the Swagger UIs for `auth-service`, `users-service`, and `payments-service`, then point to `docs/contracts/<service>/latest.json` as the published contract snapshot.
 2. Show the GenX API handoff.
    Open `genxapi.users.config.json` and `genxapi.config.json`, then point to `sdk/users-sdk` and `sdk/payments-sdk` as the generated downstream packages.
+   If you want the GitHub-native adoption path after the local demo, point to [`genxapi-action`](https://github.com/genxapi/genxapi-action).
 3. Show customer self-service in `web-app`.
    Use Bob Smith first because his account shows both normal payment history and a refund. Switch to Ethan Williams if you want a simpler customer example.
 4. Show internal operations in `backoffice-app`.

--- a/apps/backoffice-app/src/App.tsx
+++ b/apps/backoffice-app/src/App.tsx
@@ -64,13 +64,13 @@ export default function App() {
     <div className="app-shell">
       <aside className="sidebar">
         <div className="brand">
-          <div className="brand-mark">BO</div>
+          <div className="brand-mark">GX</div>
           <div className="stack">
-            <p className="eyebrow">genxapi ecosystem</p>
-            <h1>Backoffice App</h1>
+            <p className="eyebrow">GenX API Internal Surface</p>
+            <h1>Operations Console</h1>
             <p className="sidebar-copy">
-              Internal operations consumer built on the same published contracts and generated SDKs
-              as the customer app.
+              Internal operations consumer built on the same published contracts and generated SDK
+              packages as the customer surfaces.
             </p>
           </div>
         </div>
@@ -124,7 +124,7 @@ export default function App() {
 
         <section className="sidebar-card runtime-card">
           <p className="label">SDK boundary</p>
-          <p className="value">Runtime-configured generated clients</p>
+          <p className="value">Runtime-configured SDK packages</p>
           <p className="muted">
             Base URLs and bearer token injection stay at the app boundary instead of inside page
             components.

--- a/apps/backoffice-app/src/api/sdk.ts
+++ b/apps/backoffice-app/src/api/sdk.ts
@@ -1,5 +1,5 @@
-import { users } from '@genxapi/ecosystem-users-sdk';
-import { payments } from 'genxapi-ecosystem-payments-sdk';
+import { users } from '@genxapi-labs/ecosystem-users-sdk';
+import { payments } from '@genxapi-labs/ecosystem-payments-sdk';
 import { getCurrentAuthAccessToken } from '../auth/auth-session';
 import { createBackofficeSdks } from '../runtime';
 

--- a/apps/backoffice-app/src/auth/AuthSessionContext.tsx
+++ b/apps/backoffice-app/src/auth/AuthSessionContext.tsx
@@ -1,4 +1,4 @@
-import { isInternalRole, type LoginCredentials } from '@genxapi/ecosystem-auth-client';
+import { isInternalRole, type LoginCredentials } from '@genxapi-labs/ecosystem-auth-client';
 import {
   createContext,
   useContext,
@@ -39,7 +39,7 @@ export const AuthSessionProvider = ({ children }: PropsWithChildren) => {
       const nextSession = await backofficeAuthClient.login(credentials);
 
       if (!isInternalRole(nextSession.user.role)) {
-        throw new Error('This backoffice app only supports support and admin demo personas.');
+        throw new Error('This operations console only supports support and admin demo personas.');
       }
 
       persistAuthSession(nextSession);

--- a/apps/backoffice-app/src/auth/auth-session.ts
+++ b/apps/backoffice-app/src/auth/auth-session.ts
@@ -3,7 +3,7 @@ import {
   isInternalRole,
   type AuthSession,
   type UserRole,
-} from '@genxapi/ecosystem-auth-client';
+} from '@genxapi-labs/ecosystem-auth-client';
 
 export interface AuthSessionState {
   session: AuthSession | null;

--- a/apps/backoffice-app/src/auth/demo-personas.ts
+++ b/apps/backoffice-app/src/auth/demo-personas.ts
@@ -1,4 +1,4 @@
-import type { LoginCredentials, UserRole } from '@genxapi/ecosystem-auth-client';
+import type { LoginCredentials, UserRole } from '@genxapi-labs/ecosystem-auth-client';
 
 type InternalRole = Extract<UserRole, 'support' | 'admin'>;
 

--- a/apps/backoffice-app/src/pages/PaymentsPage.tsx
+++ b/apps/backoffice-app/src/pages/PaymentsPage.tsx
@@ -26,7 +26,7 @@ export default function PaymentsPage() {
             <h2>Admin payments queue</h2>
             <p className="subhead">
               This screen uses the generated payments SDK via <code>/payments</code> and is only
-              exposed to admin claims inside the backoffice app.
+              exposed to admin claims inside the operations console.
             </p>
           </div>
           <div className="toolbar">

--- a/apps/backoffice-app/src/pages/SessionGatePage.tsx
+++ b/apps/backoffice-app/src/pages/SessionGatePage.tsx
@@ -18,7 +18,7 @@ export default function SessionGatePage() {
       ? 'Switch to an internal persona'
       : 'Choose an internal demo session';
   const description = isInternal
-    ? 'This backoffice app authenticates against auth-service, then routes internal users and payments calls through the generated SDK layer.'
+    ? 'This operations console authenticates against auth-service, then routes internal users and payments calls through the generated SDK package layer.'
     : isAuthenticated
       ? 'Customer claims are not valid here. Pick a support or admin persona to unlock internal workflows.'
       : 'Each button signs into auth-service with a seeded support or admin account. The app does not build a separate login product flow.';
@@ -32,7 +32,7 @@ export default function SessionGatePage() {
         {isAuthenticated && user && !isInternal ? (
           <p className="state error">
             Current session: {user.name} ({formatLabel(user.role)}). Customer claims are blocked in
-            the backoffice app.
+            the operations console.
           </p>
         ) : null}
         {isInternal && user ? (
@@ -94,8 +94,8 @@ export default function SessionGatePage() {
           <p className="muted">Payments SDK base URL: {backofficePaymentsServiceBaseUrl}</p>
           <p className="muted">
             This app stays on internal routes such as <code>/users</code>, <code>/users/:id</code>,
-            and <code>/payments</code>. Customer-only <code>/me</code> flows remain in{' '}
-            <code>web-app</code>.
+            and <code>/payments</code>. Customer-only <code>/me</code> flows remain in the customer
+            portal.
           </p>
           {isAuthenticated && user && !isInternal ? (
             <button className="button button--secondary" type="button" onClick={signOut}>

--- a/apps/backoffice-app/src/pages/UsersPage.tsx
+++ b/apps/backoffice-app/src/pages/UsersPage.tsx
@@ -24,7 +24,7 @@ export default function UsersPage() {
         <p className="subhead">
           The users list is loaded from the generated users SDK via <code>/users</code>. Visible
           workflows follow the stored <code>{formatLabel(role ?? undefined)}</code> claim instead of
-          treating backoffice as a public app.
+          treating the operations console as a public app.
         </p>
       </section>
 

--- a/apps/backoffice-app/src/runtime.ts
+++ b/apps/backoffice-app/src/runtime.ts
@@ -1,6 +1,6 @@
-import { createAuthClient } from '@genxapi/ecosystem-auth-client';
-import { createUsersSdk } from '@genxapi/ecosystem-users-sdk';
-import { createPaymentsSdk } from 'genxapi-ecosystem-payments-sdk';
+import { createAuthClient } from '@genxapi-labs/ecosystem-auth-client';
+import { createUsersSdk } from '@genxapi-labs/ecosystem-users-sdk';
+import { createPaymentsSdk } from '@genxapi-labs/ecosystem-payments-sdk';
 
 type AccessTokenProvider =
   | string

--- a/apps/backoffice-app/src/styles.css
+++ b/apps/backoffice-app/src/styles.css
@@ -1,21 +1,27 @@
 :root {
-  --ink-strong: #f3f4f6;
-  --ink-soft: #cbd5e1;
-  --copy: #0f172a;
-  --copy-soft: #475569;
-  --line: #dbe3ee;
+  color-scheme: light;
+  --ink-strong: #f5f8ff;
+  --ink-soft: #b8c4df;
+  --copy: #0c1224;
+  --copy-soft: #5d6682;
+  --line: #e3e7f2;
   --panel: rgba(255, 255, 255, 0.92);
   --panel-strong: #ffffff;
-  --sidebar: #121826;
-  --sidebar-line: rgba(148, 163, 184, 0.18);
-  --accent: #f59e0b;
-  --accent-soft: rgba(245, 158, 11, 0.16);
-  --shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
-  font-family: 'IBM Plex Sans', system-ui, sans-serif;
+  --panel-soft: #f4f7ff;
+  --sidebar: #0c1224;
+  --sidebar-line: rgba(159, 176, 214, 0.18);
+  --primary: #1e4af5;
+  --primary-soft: #5fa9ff;
+  --accent: #1bb36f;
+  --primary-tint: rgba(30, 74, 245, 0.14);
+  --accent-tint: rgba(27, 179, 111, 0.14);
+  --shadow: 0 24px 56px rgba(12, 18, 36, 0.12);
+  font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
   color: var(--copy);
   background:
-    radial-gradient(circle at top right, rgba(245, 158, 11, 0.14), transparent 24%),
-    linear-gradient(180deg, #eef2f7 0%, #dde6f0 100%);
+    radial-gradient(circle at top right, rgba(30, 74, 245, 0.16), transparent 22%),
+    radial-gradient(circle at top left, rgba(27, 179, 111, 0.1), transparent 22%),
+    linear-gradient(180deg, #f8fbff 0%, #edf3ff 100%);
 }
 
 * {
@@ -26,8 +32,9 @@ body {
   margin: 0;
   min-height: 100vh;
   background:
-    radial-gradient(circle at top right, rgba(245, 158, 11, 0.14), transparent 24%),
-    linear-gradient(180deg, #eef2f7 0%, #dde6f0 100%);
+    radial-gradient(circle at top right, rgba(30, 74, 245, 0.16), transparent 22%),
+    radial-gradient(circle at top left, rgba(27, 179, 111, 0.1), transparent 22%),
+    linear-gradient(180deg, #f8fbff 0%, #edf3ff 100%);
 }
 
 a {
@@ -36,24 +43,29 @@ a {
 }
 
 code {
-  font-family: 'SFMono-Regular', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-family: "DM Mono", "SFMono-Regular", Menlo, monospace;
   font-size: 0.92em;
 }
 
 h1 {
   margin: 0;
-  font-size: clamp(2rem, 3vw, 2.8rem);
+  font-size: clamp(2rem, 3vw, 2.9rem);
   color: #ffffff;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
 }
 
 h2 {
   margin: 0 0 10px;
-  font-size: 1.5rem;
+  font-size: clamp(1.45rem, 2.3vw, 1.95rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
 }
 
 h3 {
   margin: 0 0 10px;
-  font-size: 1.12rem;
+  font-size: 1.1rem;
+  line-height: 1.2;
 }
 
 .app-shell {
@@ -65,8 +77,9 @@ h3 {
 .sidebar {
   padding: 36px 24px;
   background:
-    radial-gradient(circle at top right, rgba(245, 158, 11, 0.22), transparent 28%),
-    linear-gradient(180deg, #182030 0%, #121826 100%);
+    radial-gradient(circle at top right, rgba(95, 169, 255, 0.24), transparent 26%),
+    radial-gradient(circle at bottom left, rgba(27, 179, 111, 0.14), transparent 22%),
+    linear-gradient(180deg, #141c33 0%, var(--sidebar) 100%);
   color: var(--ink-strong);
   border-right: 1px solid var(--sidebar-line);
   display: flex;
@@ -81,23 +94,23 @@ h3 {
 }
 
 .brand-mark {
-  width: 52px;
-  height: 52px;
-  border-radius: 16px;
+  width: 54px;
+  height: 54px;
+  border-radius: 18px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-weight: 800;
   letter-spacing: 0.08em;
-  background: linear-gradient(135deg, rgba(245, 158, 11, 0.9), rgba(249, 115, 22, 0.85));
-  color: #111827;
-  box-shadow: 0 14px 30px rgba(245, 158, 11, 0.18);
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  color: #ffffff;
+  box-shadow: 0 18px 34px rgba(30, 74, 245, 0.26);
 }
 
 .sidebar-copy {
   margin: 0;
   color: var(--ink-soft);
-  line-height: 1.55;
+  line-height: 1.6;
 }
 
 .content {
@@ -107,13 +120,14 @@ h3 {
 .eyebrow {
   margin: 0 0 8px;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: 0.75rem;
-  color: var(--copy-soft);
+  letter-spacing: 0.22em;
+  font-size: 0.72rem;
+  color: var(--primary);
+  font-weight: 700;
 }
 
 .sidebar .eyebrow {
-  color: rgba(226, 232, 240, 0.78);
+  color: #9fc0ff;
 }
 
 .page {
@@ -137,7 +151,7 @@ h3 {
 .muted {
   margin: 0;
   color: var(--copy-soft);
-  line-height: 1.55;
+  line-height: 1.65;
 }
 
 .sidebar .muted {
@@ -146,12 +160,12 @@ h3 {
 
 .card,
 .sidebar-card {
-  padding: 20px;
-  border-radius: 20px;
+  padding: 24px;
+  border-radius: 24px;
   border: 1px solid var(--line);
   background: var(--panel);
   box-shadow: var(--shadow);
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(10px);
 }
 
 .sidebar-card {
@@ -162,7 +176,7 @@ h3 {
 
 .hero-panel {
   background:
-    linear-gradient(135deg, rgba(245, 158, 11, 0.1), rgba(15, 23, 42, 0.03)),
+    linear-gradient(135deg, rgba(30, 74, 245, 0.1), rgba(255, 255, 255, 0.98) 58%, rgba(27, 179, 111, 0.08)),
     var(--panel-strong);
 }
 
@@ -170,7 +184,7 @@ h3 {
 .summary-card .value,
 .detail-list .value,
 .persona-card .value {
-  font-size: 1.1rem;
+  font-size: 1.08rem;
   font-weight: 700;
   color: var(--copy);
 }
@@ -181,14 +195,15 @@ h3 {
 
 .label {
   margin: 0;
-  font-size: 0.8rem;
+  font-size: 0.76rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   color: var(--copy-soft);
+  font-weight: 700;
 }
 
 .sidebar .label {
-  color: rgba(226, 232, 240, 0.7);
+  color: rgba(216, 226, 248, 0.72);
 }
 
 .app-nav {
@@ -199,24 +214,29 @@ h3 {
 
 .nav-link {
   padding: 14px 16px;
-  border-radius: 16px;
-  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 18px;
+  border: 1px solid rgba(159, 176, 214, 0.14);
   background: rgba(255, 255, 255, 0.03);
   display: flex;
   flex-direction: column;
   gap: 4px;
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .nav-link:hover {
-  border-color: rgba(245, 158, 11, 0.5);
-  background: rgba(245, 158, 11, 0.08);
+  border-color: rgba(95, 169, 255, 0.42);
+  background: rgba(30, 74, 245, 0.12);
   transform: translateX(2px);
 }
 
 .nav-link.active {
-  border-color: rgba(245, 158, 11, 0.55);
-  background: var(--accent-soft);
+  border-color: rgba(95, 169, 255, 0.55);
+  background: rgba(30, 74, 245, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(95, 169, 255, 0.14);
 }
 
 .nav-link__label {
@@ -227,7 +247,7 @@ h3 {
 .nav-link__help,
 .nav-empty {
   color: var(--ink-soft);
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
 .stack {
@@ -262,9 +282,15 @@ h3 {
   gap: 14px;
 }
 
+.summary-card {
+  background: var(--panel-soft);
+  border-color: rgba(30, 74, 245, 0.08);
+  box-shadow: none;
+}
+
 .persona-card--active {
-  border-color: rgba(245, 158, 11, 0.45);
-  box-shadow: 0 18px 44px rgba(245, 158, 11, 0.14);
+  border-color: rgba(30, 74, 245, 0.34);
+  box-shadow: 0 20px 42px rgba(30, 74, 245, 0.12);
 }
 
 .persona-meta {
@@ -280,12 +306,15 @@ h3 {
 
 .button {
   border: 0;
-  border-radius: 12px;
-  padding: 10px 14px;
+  border-radius: 14px;
+  padding: 10px 16px;
   font-size: 0.95rem;
   font-weight: 700;
   cursor: pointer;
-  transition: transform 0.2s ease, opacity 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .button:hover:not(:disabled) {
@@ -294,17 +323,19 @@ h3 {
 
 .button:disabled {
   cursor: wait;
-  opacity: 0.7;
+  opacity: 0.72;
 }
 
 .button--primary {
-  background: #111827;
+  background: linear-gradient(135deg, var(--primary), #1940d6);
   color: #ffffff;
+  box-shadow: 0 16px 30px rgba(30, 74, 245, 0.22);
 }
 
 .button--secondary {
-  background: #e2e8f0;
-  color: #111827;
+  background: var(--panel-strong);
+  color: var(--copy);
+  border: 1px solid var(--line);
 }
 
 .table-wrap {
@@ -322,20 +353,20 @@ h3 {
 .table td {
   text-align: left;
   padding: 12px;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--line);
   vertical-align: top;
 }
 
 .table thead {
-  background: #f8fafc;
+  background: rgba(244, 247, 255, 0.94);
   color: var(--copy-soft);
   font-size: 0.82rem;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
 }
 
 .table tbody tr:hover {
-  background: rgba(245, 158, 11, 0.04);
+  background: rgba(30, 74, 245, 0.04);
 }
 
 .detail-list {
@@ -358,68 +389,60 @@ h3 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 10px;
+  padding: 5px 11px;
   border-radius: 999px;
   font-size: 0.72rem;
   font-weight: 800;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  background: #e2e8f0;
-  color: #334155;
+  background: rgba(12, 18, 36, 0.06);
+  color: var(--copy-soft);
 }
 
 .badge--customer {
-  background: #dbeafe;
-  color: #1d4ed8;
+  background: rgba(93, 102, 130, 0.12);
+  color: var(--copy-soft);
 }
 
 .badge--support {
-  background: #cffafe;
-  color: #0f766e;
+  background: rgba(95, 169, 255, 0.14);
+  color: var(--primary);
 }
 
 .badge--admin {
-  background: #fde68a;
-  color: #92400e;
+  background: rgba(27, 179, 111, 0.14);
+  color: #0f7a4a;
 }
 
-.badge--active {
-  background: #dcfce7;
-  color: #166534;
+.badge--active,
+.badge--completed {
+  background: rgba(27, 179, 111, 0.14);
+  color: #0f7a4a;
 }
 
-.badge--inactive {
-  background: #fee2e2;
-  color: #991b1b;
+.badge--inactive,
+.badge--failed {
+  background: rgba(220, 38, 38, 0.1);
+  color: #b42318;
 }
 
 .badge--pending {
-  background: #fef3c7;
-  color: #92400e;
-}
-
-.badge--completed {
-  background: #dbeafe;
-  color: #1e3a8a;
-}
-
-.badge--failed {
-  background: #fee2e2;
-  color: #991b1b;
+  background: rgba(217, 119, 6, 0.12);
+  color: #b45309;
 }
 
 .badge--refunded {
-  background: #ede9fe;
-  color: #5b21b6;
+  background: rgba(76, 81, 255, 0.1);
+  color: #4254d0;
 }
 
 .inline-link {
-  color: #b45309;
+  color: var(--primary);
   font-weight: 700;
 }
 
 .inline-link:hover {
-  color: #92400e;
+  color: #1940d6;
 }
 
 .session-user {
@@ -434,7 +457,7 @@ h3 {
 }
 
 .state.error {
-  color: #b91c1c;
+  color: #b42318;
 }
 
 @media (max-width: 960px) {
@@ -456,12 +479,16 @@ h3 {
 
   .card,
   .sidebar-card {
-    padding: 16px;
-    border-radius: 16px;
+    padding: 20px;
+    border-radius: 22px;
   }
 
   .table th,
   .table td {
     padding: 10px;
+  }
+
+  .button {
+    width: 100%;
   }
 }

--- a/apps/mobile-app/App.tsx
+++ b/apps/mobile-app/App.tsx
@@ -7,6 +7,7 @@ import MyPaymentsScreen from './src/screens/MyPaymentsScreen';
 import MyProfileScreen from './src/screens/MyProfileScreen';
 import SessionGateScreen from './src/screens/SessionGateScreen';
 import { queryClient } from './src/query-client';
+import { cardShadow, theme } from './src/theme';
 
 type AppScreen = 'profile' | 'payments';
 
@@ -30,11 +31,11 @@ function MobileCustomerShell() {
       <StatusBar style="dark" />
       <ScrollView contentContainerStyle={styles.content}>
         <View style={styles.heroCard}>
-          <Text style={styles.eyebrow}>genxapi ecosystem</Text>
-          <Text style={styles.title}>Customer Self-Service Mobile Demo</Text>
+          <Text style={styles.eyebrow}>GenX API Customer Surface</Text>
+          <Text style={styles.title}>Customer Mobile</Text>
           <Text style={styles.subtitle}>
-            `mobile-app` now acts as the second customer consumer, reusing the same runtime-configured
-            generated SDK boundary as `web-app`.
+            Second customer consumer reusing the same runtime-configured SDK packages and published
+            contract workflow as the web portal.
           </Text>
         </View>
 
@@ -108,44 +109,48 @@ export default function App() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#f5efe6',
+    backgroundColor: theme.colors.background,
   },
   content: {
     paddingHorizontal: 20,
     paddingVertical: 18,
-    gap: 16,
+    gap: 18,
   },
   heroCard: {
-    borderRadius: 28,
-    padding: 24,
-    backgroundColor: '#123524',
+    borderRadius: theme.radius.xl,
+    padding: theme.spacing.xl,
+    borderWidth: 1,
+    borderColor: 'rgba(95, 169, 255, 0.4)',
+    backgroundColor: theme.colors.navy,
+    ...cardShadow,
   },
   eyebrow: {
-    color: '#d4f2d2',
+    color: theme.colors.primarySoft,
     fontSize: 11,
     fontWeight: '700',
-    letterSpacing: 1.6,
+    letterSpacing: 1.7,
     marginBottom: 12,
     textTransform: 'uppercase',
   },
   title: {
-    color: '#f8fbf6',
+    color: theme.colors.surface,
     fontSize: 30,
     fontWeight: '800',
     lineHeight: 36,
   },
   subtitle: {
-    color: '#c3ddc9',
+    color: '#d6e0fb',
     fontSize: 15,
     lineHeight: 22,
     marginTop: 12,
   },
   sessionCard: {
-    backgroundColor: '#fffaf3',
-    borderColor: '#d9d2c3',
-    borderRadius: 24,
+    backgroundColor: theme.colors.surface,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.lg,
     borderWidth: 1,
-    padding: 20,
+    padding: theme.spacing.lg,
+    ...cardShadow,
   },
   sessionHeader: {
     gap: 16,
@@ -154,19 +159,19 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   sectionEyebrow: {
-    color: '#7b6b4f',
+    color: theme.colors.primary,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
     textTransform: 'uppercase',
   },
   sessionTitle: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 20,
     fontWeight: '700',
   },
   sessionSubtitle: {
-    color: '#5d665f',
+    color: theme.colors.muted,
     fontSize: 14,
     lineHeight: 20,
   },
@@ -175,53 +180,60 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   customerBadge: {
-    backgroundColor: '#d9f3d7',
+    backgroundColor: theme.colors.surfaceSoft,
     borderRadius: 999,
     paddingHorizontal: 12,
     paddingVertical: 6,
   },
   customerBadgeText: {
-    color: '#245b30',
+    color: theme.colors.primary,
     fontSize: 12,
     fontWeight: '700',
   },
   sessionEmail: {
-    color: '#405046',
+    color: theme.colors.muted,
     fontSize: 14,
   },
   secondaryButton: {
-    backgroundColor: '#eff1eb',
+    backgroundColor: theme.colors.surfaceSoft,
+    borderColor: theme.colors.border,
     borderRadius: 999,
+    borderWidth: 1,
     paddingHorizontal: 16,
     paddingVertical: 10,
   },
   secondaryButtonText: {
-    color: '#233127',
+    color: theme.colors.navy,
     fontSize: 14,
     fontWeight: '700',
   },
   tabBar: {
-    backgroundColor: '#e4ddcf',
-    borderRadius: 20,
+    backgroundColor: theme.colors.surfaceSoft,
+    borderRadius: 22,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
     flexDirection: 'row',
     padding: 4,
   },
   tabButton: {
     alignItems: 'center',
-    borderRadius: 16,
+    borderRadius: 18,
     flex: 1,
     paddingHorizontal: 12,
     paddingVertical: 14,
   },
   tabButtonActive: {
-    backgroundColor: '#ffffff',
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.borderStrong,
+    ...cardShadow,
   },
   tabButtonText: {
-    color: '#675a45',
+    color: theme.colors.muted,
     fontSize: 14,
     fontWeight: '700',
   },
   tabButtonTextActive: {
-    color: '#133923',
+    color: theme.colors.primary,
   },
 });

--- a/apps/mobile-app/package-lock.json
+++ b/apps/mobile-app/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mobile-app",
       "version": "0.0.0",
       "dependencies": {
-        "@genxapi/ecosystem-auth-client": "file:../../libs/auth-client",
+        "@genxapi-labs/ecosystem-auth-client": "file:../../libs/auth-client",
         "expo": "^50.0.0",
         "expo-status-bar": "~1.11.0",
         "react": "18.2.0",
@@ -21,7 +21,7 @@
       }
     },
     "../../libs/auth-client": {
-      "name": "@genxapi/ecosystem-auth-client",
+      "name": "@genxapi-labs/ecosystem-auth-client",
       "version": "0.1.0"
     },
     "node_modules/@babel/code-frame": {
@@ -3201,7 +3201,7 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT"
     },
-    "node_modules/@genxapi/ecosystem-auth-client": {
+    "node_modules/@genxapi-labs/ecosystem-auth-client": {
       "resolved": "../../libs/auth-client",
       "link": true
     },

--- a/apps/mobile-app/package.json
+++ b/apps/mobile-app/package.json
@@ -10,7 +10,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@genxapi/ecosystem-auth-client": "file:../../libs/auth-client",
+    "@genxapi-labs/ecosystem-auth-client": "file:../../libs/auth-client",
     "expo": "^50.0.0",
     "expo-status-bar": "~1.11.0",
     "react": "18.2.0",

--- a/apps/mobile-app/runtime.ts
+++ b/apps/mobile-app/runtime.ts
@@ -1,6 +1,6 @@
-import { createAuthClient } from '@genxapi/ecosystem-auth-client';
-import { createUsersSdk } from '@genxapi/ecosystem-users-sdk';
-import { createPaymentsSdk } from 'genxapi-ecosystem-payments-sdk';
+import { createAuthClient } from '@genxapi-labs/ecosystem-auth-client';
+import { createUsersSdk } from '@genxapi-labs/ecosystem-users-sdk';
+import { createPaymentsSdk } from '@genxapi-labs/ecosystem-payments-sdk';
 
 export type MobileAccessTokenProvider =
   | string

--- a/apps/mobile-app/src/api/sdk.ts
+++ b/apps/mobile-app/src/api/sdk.ts
@@ -1,5 +1,5 @@
-import { users } from '@genxapi/ecosystem-users-sdk';
-import { payments } from 'genxapi-ecosystem-payments-sdk';
+import { users } from '@genxapi-labs/ecosystem-users-sdk';
+import { payments } from '@genxapi-labs/ecosystem-payments-sdk';
 import { createMobileSdks, type MobileAccessTokenProvider } from '../../runtime';
 import { useAuthSession } from '../auth/AuthSessionContext';
 

--- a/apps/mobile-app/src/auth/AuthSessionContext.tsx
+++ b/apps/mobile-app/src/auth/AuthSessionContext.tsx
@@ -1,4 +1,4 @@
-import type { LoginCredentials } from '@genxapi/ecosystem-auth-client';
+import type { LoginCredentials } from '@genxapi-labs/ecosystem-auth-client';
 import {
   createContext,
   useContext,

--- a/apps/mobile-app/src/auth/auth-session.ts
+++ b/apps/mobile-app/src/auth/auth-session.ts
@@ -1,4 +1,4 @@
-import type { AuthSession } from '@genxapi/ecosystem-auth-client';
+import type { AuthSession } from '@genxapi-labs/ecosystem-auth-client';
 
 export interface AuthSessionState {
   session: AuthSession | null;

--- a/apps/mobile-app/src/auth/demo-personas.ts
+++ b/apps/mobile-app/src/auth/demo-personas.ts
@@ -1,4 +1,4 @@
-import type { LoginCredentials } from '@genxapi/ecosystem-auth-client';
+import type { LoginCredentials } from '@genxapi-labs/ecosystem-auth-client';
 
 export interface DemoPersona extends LoginCredentials {
   id: 'bob-smith' | 'ethan-williams';

--- a/apps/mobile-app/src/screens/MyPaymentsScreen.tsx
+++ b/apps/mobile-app/src/screens/MyPaymentsScreen.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import { type CustomerPayment, useCustomerMobileApi } from '../api/sdk';
 import { useAuthSession } from '../auth/AuthSessionContext';
+import { cardShadow, theme } from '../theme';
 import {
   formatCurrency,
   formatDateTime,
@@ -59,14 +60,14 @@ export default function MyPaymentsScreen() {
         <Text style={styles.eyebrow}>My Payments</Text>
         <Text style={styles.title}>Your payment history</Text>
         <Text style={styles.description}>
-          This screen uses the generated payments SDK against /me/payments, so every record shown
-          belongs to the authenticated customer.
+          This screen uses the generated payments SDK package against /me/payments, so every record
+          shown belongs to the authenticated customer.
         </Text>
       </View>
 
       {paymentsQuery.isLoading ? (
         <View style={styles.card}>
-          <ActivityIndicator color="#123524" />
+          <ActivityIndicator color={theme.colors.primary} />
           <Text style={styles.stateText}>Loading your payments...</Text>
         </View>
       ) : null}
@@ -166,14 +167,15 @@ const styles = StyleSheet.create({
     gap: 16,
   },
   heroCard: {
-    backgroundColor: '#edf6f7',
-    borderColor: '#c6d9de',
-    borderRadius: 24,
+    backgroundColor: theme.colors.surfaceSoft,
+    borderColor: theme.colors.borderStrong,
+    borderRadius: theme.radius.lg,
     borderWidth: 1,
-    padding: 20,
+    padding: theme.spacing.lg,
+    ...cardShadow,
   },
   eyebrow: {
-    color: '#2a6d7d',
+    color: theme.colors.primary,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
@@ -181,44 +183,47 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   title: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 24,
     fontWeight: '700',
   },
   description: {
-    color: '#5d665f',
+    color: theme.colors.muted,
     fontSize: 15,
     lineHeight: 22,
     marginTop: 10,
   },
   card: {
-    backgroundColor: '#fffaf3',
-    borderColor: '#d9d2c3',
-    borderRadius: 24,
+    backgroundColor: theme.colors.surface,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.lg,
     borderWidth: 1,
     gap: 14,
-    padding: 20,
+    padding: theme.spacing.lg,
+    ...cardShadow,
   },
   stateText: {
-    color: '#405046',
+    color: theme.colors.muted,
     fontSize: 15,
     lineHeight: 22,
   },
   errorText: {
-    color: '#a11d1d',
+    color: theme.colors.danger,
     fontSize: 14,
     lineHeight: 20,
   },
   secondaryButton: {
     alignItems: 'center',
     alignSelf: 'flex-start',
-    backgroundColor: '#eff1eb',
-    borderRadius: 18,
+    backgroundColor: theme.colors.surfaceSoft,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.md,
+    borderWidth: 1,
     paddingHorizontal: 16,
     paddingVertical: 12,
   },
   secondaryButtonText: {
-    color: '#233127',
+    color: theme.colors.navy,
     fontSize: 14,
     fontWeight: '700',
   },
@@ -226,14 +231,15 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   summaryCard: {
-    backgroundColor: '#fffaf3',
-    borderColor: '#d9d2c3',
-    borderRadius: 24,
+    backgroundColor: theme.colors.surface,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.lg,
     borderWidth: 1,
     padding: 18,
+    ...cardShadow,
   },
   summaryLabel: {
-    color: '#7b6b4f',
+    color: theme.colors.primary,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
@@ -241,23 +247,23 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   summaryValue: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 22,
     fontWeight: '700',
   },
   summaryDescription: {
-    color: '#5d665f',
+    color: theme.colors.muted,
     fontSize: 14,
     lineHeight: 20,
     marginTop: 8,
   },
   cardTitle: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 20,
     fontWeight: '700',
   },
   cardDescription: {
-    color: '#5d665f',
+    color: theme.colors.muted,
     fontSize: 14,
     lineHeight: 20,
   },
@@ -265,7 +271,7 @@ const styles = StyleSheet.create({
     gap: 14,
   },
   paymentCard: {
-    backgroundColor: '#f6f0e4',
+    backgroundColor: theme.colors.surfaceSoft,
     borderRadius: 20,
     gap: 12,
     padding: 16,
@@ -276,12 +282,12 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   amountText: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 20,
     fontWeight: '700',
   },
   dateText: {
-    color: '#5d665f',
+    color: theme.colors.muted,
     fontSize: 13,
     marginTop: 6,
   },
@@ -291,45 +297,45 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
   },
   statusBadgeCompleted: {
-    backgroundColor: '#d9f3d7',
+    backgroundColor: theme.colors.successSurface,
   },
   statusBadgePending: {
-    backgroundColor: '#feefc3',
+    backgroundColor: theme.colors.warningSurface,
   },
   statusBadgeRefunded: {
-    backgroundColor: '#ecdfff',
+    backgroundColor: theme.colors.refundedSurface,
   },
   statusBadgeFailed: {
-    backgroundColor: '#fde2df',
+    backgroundColor: theme.colors.dangerSurface,
   },
   statusBadgeText: {
     fontSize: 12,
     fontWeight: '700',
   },
   statusBadgeTextCompleted: {
-    color: '#245b30',
+    color: theme.colors.success,
   },
   statusBadgeTextPending: {
-    color: '#8a5a00',
+    color: theme.colors.warning,
   },
   statusBadgeTextRefunded: {
-    color: '#5c2ca6',
+    color: theme.colors.refunded,
   },
   statusBadgeTextFailed: {
-    color: '#9e1c1c',
+    color: theme.colors.danger,
   },
   metaRow: {
     gap: 4,
   },
   metaLabel: {
-    color: '#7b6b4f',
+    color: theme.colors.primary,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
     textTransform: 'uppercase',
   },
   metaValue: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 15,
     lineHeight: 20,
   },

--- a/apps/mobile-app/src/screens/MyProfileScreen.tsx
+++ b/apps/mobile-app/src/screens/MyProfileScreen.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useCustomerMobileApi } from '../api/sdk';
 import { useAuthSession } from '../auth/AuthSessionContext';
+import { cardShadow, theme } from '../theme';
 import { formatDateTime, formatLabel, getErrorMessage } from '../utils/format';
 
 export default function MyProfileScreen() {
@@ -21,14 +22,14 @@ export default function MyProfileScreen() {
           {profileQuery.data ? `Welcome back, ${profileQuery.data.firstName}.` : 'Your account at a glance'}
         </Text>
         <Text style={styles.description}>
-          This screen reads the authenticated customer record from /me through the generated users SDK.
-          There is no cross-user navigation in the mobile app.
+          This screen reads the authenticated customer record from /me through the generated users
+          SDK package. There is no cross-user navigation in the mobile app.
         </Text>
       </View>
 
       {profileQuery.isLoading ? (
         <View style={styles.card}>
-          <ActivityIndicator color="#123524" />
+          <ActivityIndicator color={theme.colors.primary} />
           <Text style={styles.stateText}>Loading your profile...</Text>
         </View>
       ) : null}
@@ -111,9 +112,10 @@ export default function MyProfileScreen() {
               </View>
               <View style={styles.summaryBlock}>
                 <Text style={styles.summaryLabel}>Runtime adoption</Text>
-                <Text style={styles.summaryValue}>Generated SDK + app session</Text>
+                <Text style={styles.summaryValue}>SDK package + app session</Text>
                 <Text style={styles.summaryDescription}>
-                  Base URLs and bearer token injection stay at the app boundary instead of inside the screen.
+                  Base URLs and bearer token injection stay at the app boundary instead of inside the
+                  screen.
                 </Text>
               </View>
             </View>
@@ -129,14 +131,15 @@ const styles = StyleSheet.create({
     gap: 16,
   },
   heroCard: {
-    backgroundColor: '#fef6e8',
-    borderColor: '#ead9b8',
-    borderRadius: 24,
+    backgroundColor: theme.colors.surfaceSoft,
+    borderColor: theme.colors.borderStrong,
+    borderRadius: theme.radius.lg,
     borderWidth: 1,
-    padding: 20,
+    padding: theme.spacing.lg,
+    ...cardShadow,
   },
   eyebrow: {
-    color: '#956f16',
+    color: theme.colors.primary,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
@@ -144,43 +147,46 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   title: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 24,
     fontWeight: '700',
   },
   description: {
-    color: '#5d665f',
+    color: theme.colors.muted,
     fontSize: 15,
     lineHeight: 22,
     marginTop: 10,
   },
   card: {
-    backgroundColor: '#fffaf3',
-    borderColor: '#d9d2c3',
-    borderRadius: 24,
+    backgroundColor: theme.colors.surface,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.lg,
     borderWidth: 1,
     gap: 14,
-    padding: 20,
+    padding: theme.spacing.lg,
+    ...cardShadow,
   },
   stateText: {
-    color: '#405046',
+    color: theme.colors.muted,
     fontSize: 15,
   },
   errorText: {
-    color: '#a11d1d',
+    color: theme.colors.danger,
     fontSize: 14,
     lineHeight: 20,
   },
   secondaryButton: {
     alignItems: 'center',
     alignSelf: 'flex-start',
-    backgroundColor: '#eff1eb',
-    borderRadius: 18,
+    backgroundColor: theme.colors.surfaceSoft,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.md,
+    borderWidth: 1,
     paddingHorizontal: 16,
     paddingVertical: 12,
   },
   secondaryButtonText: {
-    color: '#233127',
+    color: theme.colors.navy,
     fontSize: 14,
     fontWeight: '700',
   },
@@ -190,32 +196,32 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   cardTitle: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 20,
     fontWeight: '700',
   },
   badge: {
-    backgroundColor: '#d9f3d7',
+    backgroundColor: theme.colors.surfaceSoft,
     borderRadius: 999,
     paddingHorizontal: 12,
     paddingVertical: 6,
   },
   badgeText: {
-    color: '#245b30',
+    color: theme.colors.primary,
     fontSize: 12,
     fontWeight: '700',
   },
   successBadge: {
-    backgroundColor: '#d9f3d7',
+    backgroundColor: theme.colors.successSurface,
   },
   successBadgeText: {
-    color: '#245b30',
+    color: theme.colors.success,
   },
   inactiveBadge: {
-    backgroundColor: '#ece7df',
+    backgroundColor: theme.colors.surfaceMuted,
   },
   inactiveBadgeText: {
-    color: '#6d6558',
+    color: theme.colors.muted,
   },
   detailList: {
     gap: 16,
@@ -224,14 +230,14 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   detailLabel: {
-    color: '#7b6b4f',
+    color: theme.colors.primary,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
     textTransform: 'uppercase',
   },
   detailValue: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 16,
     lineHeight: 22,
   },
@@ -240,12 +246,12 @@ const styles = StyleSheet.create({
     marginTop: 14,
   },
   summaryBlock: {
-    backgroundColor: '#f6f0e4',
+    backgroundColor: theme.colors.surfaceSoft,
     borderRadius: 20,
     padding: 16,
   },
   summaryLabel: {
-    color: '#7b6b4f',
+    color: theme.colors.primary,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
@@ -253,12 +259,12 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   summaryValue: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 17,
     fontWeight: '700',
   },
   summaryDescription: {
-    color: '#5d665f',
+    color: theme.colors.muted,
     fontSize: 14,
     lineHeight: 20,
     marginTop: 8,

--- a/apps/mobile-app/src/screens/SessionGateScreen.tsx
+++ b/apps/mobile-app/src/screens/SessionGateScreen.tsx
@@ -7,6 +7,7 @@ import {
   mobileUsersServiceBaseUrl,
 } from '../../runtime';
 import { useAuthSession } from '../auth/AuthSessionContext';
+import { cardShadow, theme } from '../theme';
 
 const runtimeRows = [
   {
@@ -31,12 +32,12 @@ export default function SessionGateScreen() {
     isAuthenticated && !isCustomer ? 'Switch to a customer demo persona' : 'Choose a customer demo session';
   const description =
     isAuthenticated && !isCustomer
-      ? 'This mobile app is intentionally scoped to customer self-service. Internal support and admin flows stay in backoffice-app.'
-      : 'Each persona signs into auth-service, then the app loads only /me and /me/payments through the generated SDK layer.';
+      ? 'This mobile app is intentionally scoped to customer self-service. Internal support and admin flows stay in the operations console.'
+      : 'Each persona signs into auth-service, then the app loads only /me and /me/payments through the generated SDK package layer.';
 
   return (
     <View style={styles.screen}>
-      <View style={styles.card}>
+      <View style={styles.heroCard}>
         <Text style={styles.eyebrow}>Customer Access</Text>
         <Text style={styles.title}>{title}</Text>
         <Text style={styles.description}>{description}</Text>
@@ -112,15 +113,24 @@ const styles = StyleSheet.create({
   screen: {
     gap: 16,
   },
-  card: {
-    backgroundColor: '#fffaf3',
-    borderColor: '#d9d2c3',
-    borderRadius: 24,
+  heroCard: {
+    backgroundColor: theme.colors.surfaceSoft,
+    borderColor: theme.colors.borderStrong,
+    borderRadius: theme.radius.lg,
     borderWidth: 1,
-    padding: 20,
+    padding: theme.spacing.lg,
+    ...cardShadow,
+  },
+  card: {
+    backgroundColor: theme.colors.surface,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.lg,
+    borderWidth: 1,
+    padding: theme.spacing.lg,
+    ...cardShadow,
   },
   eyebrow: {
-    color: '#7b6b4f',
+    color: theme.colors.primary,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
@@ -128,12 +138,12 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   title: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 22,
     fontWeight: '700',
   },
   description: {
-    color: '#5d665f',
+    color: theme.colors.muted,
     fontSize: 15,
     lineHeight: 22,
     marginTop: 10,
@@ -148,50 +158,50 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   personaLabel: {
-    color: '#7b6b4f',
+    color: theme.colors.primary,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
     textTransform: 'uppercase',
   },
   personaName: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 20,
     fontWeight: '700',
   },
   personaEmail: {
-    color: '#4b5a51',
+    color: theme.colors.muted,
     fontSize: 14,
   },
   personaDescription: {
-    color: '#5d665f',
+    color: theme.colors.muted,
     fontSize: 14,
     lineHeight: 20,
     marginTop: 14,
     marginBottom: 18,
   },
   badge: {
-    backgroundColor: '#d9f3d7',
+    backgroundColor: theme.colors.surfaceSoft,
     borderRadius: 999,
     marginLeft: 12,
     paddingHorizontal: 12,
     paddingVertical: 6,
   },
   badgeText: {
-    color: '#245b30',
+    color: theme.colors.primary,
     fontSize: 12,
     fontWeight: '700',
     textTransform: 'capitalize',
   },
   primaryButton: {
     alignItems: 'center',
-    backgroundColor: '#123524',
-    borderRadius: 18,
+    backgroundColor: theme.colors.primary,
+    borderRadius: theme.radius.md,
     paddingHorizontal: 16,
     paddingVertical: 14,
   },
   primaryButtonText: {
-    color: '#f8fbf6',
+    color: theme.colors.surface,
     fontSize: 15,
     fontWeight: '700',
   },
@@ -203,7 +213,7 @@ const styles = StyleSheet.create({
     marginTop: 16,
   },
   runtimeLabel: {
-    color: '#7b6b4f',
+    color: theme.colors.primary,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
@@ -211,30 +221,32 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   runtimeValue: {
-    color: '#1d2a22',
+    color: theme.colors.navy,
     fontSize: 14,
     lineHeight: 20,
   },
   warningText: {
-    color: '#8b3d19',
+    color: theme.colors.warning,
     fontSize: 14,
     lineHeight: 20,
   },
   errorText: {
-    color: '#a11d1d',
+    color: theme.colors.danger,
     fontSize: 14,
     lineHeight: 20,
     marginTop: 12,
   },
   secondaryButton: {
     alignItems: 'center',
-    backgroundColor: '#eff1eb',
-    borderRadius: 18,
+    backgroundColor: theme.colors.surfaceSoft,
+    borderColor: theme.colors.border,
+    borderRadius: theme.radius.md,
+    borderWidth: 1,
     paddingHorizontal: 16,
     paddingVertical: 12,
   },
   secondaryButtonText: {
-    color: '#233127',
+    color: theme.colors.navy,
     fontSize: 14,
     fontWeight: '700',
   },

--- a/apps/mobile-app/src/theme.ts
+++ b/apps/mobile-app/src/theme.ts
@@ -1,0 +1,45 @@
+import type { ViewStyle } from 'react-native';
+
+export const theme = {
+  colors: {
+    background: '#f4f7ff',
+    surface: '#ffffff',
+    surfaceSoft: '#eef4ff',
+    surfaceMuted: '#f7f9fe',
+    border: '#e3e7f2',
+    borderStrong: '#cfd9ef',
+    navy: '#0c1224',
+    primary: '#1e4af5',
+    primarySoft: '#5fa9ff',
+    accent: '#1bb36f',
+    muted: '#5d6682',
+    textSoft: '#9aa7c2',
+    success: '#0f7a4a',
+    successSurface: '#e8faf0',
+    warning: '#b45309',
+    warningSurface: '#fff1dc',
+    danger: '#b42318',
+    dangerSurface: '#fdecec',
+    refunded: '#4254d0',
+    refundedSurface: '#eef0ff',
+  },
+  radius: {
+    md: 18,
+    lg: 24,
+    xl: 28,
+  },
+  spacing: {
+    sm: 12,
+    md: 16,
+    lg: 20,
+    xl: 24,
+  },
+} as const;
+
+export const cardShadow: ViewStyle = {
+  shadowColor: theme.colors.navy,
+  shadowOffset: { width: 0, height: 12 },
+  shadowOpacity: 0.08,
+  shadowRadius: 24,
+  elevation: 4,
+};

--- a/apps/web-app/src/App.tsx
+++ b/apps/web-app/src/App.tsx
@@ -25,11 +25,11 @@ export default function App() {
     <div className="app">
       <header className="app-header">
         <div className="hero-copy">
-          <p className="eyebrow">genxapi ecosystem</p>
-          <h1>Customer Self-Service Demo</h1>
+          <p className="eyebrow">GenX API Customer Surface</p>
+          <h1>Customer Portal</h1>
           <p className="subhead">
-            `web-app` now consumes the runtime-configured generated SDKs as a customer app, loading
-            only the authenticated user&apos;s profile and payments.
+            Customer-facing consumer that adopts runtime-configured SDK packages generated from
+            published service contracts, loading only the authenticated user&apos;s profile and payments.
           </p>
         </div>
         <div className="header-actions">
@@ -57,7 +57,7 @@ export default function App() {
                 </div>
                 <p className="session-note">
                   This session drives the customer-only navigation and powers `/me` plus
-                  `/me/payments` through the generated SDK layer.
+                  `/me/payments` through the generated SDK package layer.
                 </p>
               </div>
             ) : (

--- a/apps/web-app/src/api/sdk.ts
+++ b/apps/web-app/src/api/sdk.ts
@@ -1,5 +1,5 @@
-import { createUsersSdk, users } from '@genxapi/ecosystem-users-sdk';
-import { createPaymentsSdk, payments } from 'genxapi-ecosystem-payments-sdk';
+import { createUsersSdk, users } from '@genxapi-labs/ecosystem-users-sdk';
+import { createPaymentsSdk, payments } from '@genxapi-labs/ecosystem-payments-sdk';
 import { getCurrentAuthAccessToken } from '../auth/auth-session';
 
 type AccessTokenProvider =

--- a/apps/web-app/src/auth/AuthSessionContext.tsx
+++ b/apps/web-app/src/auth/AuthSessionContext.tsx
@@ -1,4 +1,4 @@
-import type { LoginCredentials } from '@genxapi/ecosystem-auth-client';
+import type { LoginCredentials } from '@genxapi-labs/ecosystem-auth-client';
 import {
   createContext,
   useContext,

--- a/apps/web-app/src/auth/auth-session.ts
+++ b/apps/web-app/src/auth/auth-session.ts
@@ -1,7 +1,7 @@
 import {
   AUTH_SESSION_STORAGE_KEY,
   type AuthSession,
-} from '@genxapi/ecosystem-auth-client';
+} from '@genxapi-labs/ecosystem-auth-client';
 
 export interface AuthSessionState {
   session: AuthSession | null;

--- a/apps/web-app/src/auth/client.ts
+++ b/apps/web-app/src/auth/client.ts
@@ -1,4 +1,4 @@
-import { createAuthClient } from '@genxapi/ecosystem-auth-client';
+import { createAuthClient } from '@genxapi-labs/ecosystem-auth-client';
 
 export const authServiceBaseUrl =
   import.meta.env.VITE_AUTH_SERVICE_BASE_URL ?? '/api/auth-service';

--- a/apps/web-app/src/auth/demo-personas.ts
+++ b/apps/web-app/src/auth/demo-personas.ts
@@ -1,4 +1,4 @@
-import type { LoginCredentials } from '@genxapi/ecosystem-auth-client';
+import type { LoginCredentials } from '@genxapi-labs/ecosystem-auth-client';
 
 export interface DemoPersona extends LoginCredentials {
   id: 'bob-smith' | 'ethan-williams';

--- a/apps/web-app/src/pages/SessionGatePage.tsx
+++ b/apps/web-app/src/pages/SessionGatePage.tsx
@@ -9,8 +9,8 @@ export default function SessionGatePage() {
     isAuthenticated && !isCustomer ? 'Switch to a customer demo persona' : 'Choose a customer demo session';
   const description =
     isAuthenticated && !isCustomer
-      ? 'This web app is intentionally scoped to customer self-service. Support and admin journeys now live in the backoffice app.'
-      : 'Each persona button signs into auth-service with a seeded customer account, then the app loads /me and /me/payments through the generated SDK layer.';
+      ? 'This web app is intentionally scoped to customer self-service. Support and admin journeys now live in the operations console.'
+      : 'Each persona button signs into auth-service with a seeded customer account, then the app loads /me and /me/payments through the generated SDK package layer.';
 
   return (
     <div className="page">

--- a/apps/web-app/src/styles.css
+++ b/apps/web-app/src/styles.css
@@ -1,7 +1,23 @@
 :root {
-  font-family: 'Space Grotesk', system-ui, sans-serif;
-  color: #0c0f12;
-  background: #f6f7f8;
+  color-scheme: light;
+  --bg: #ffffff;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-strong: #ffffff;
+  --surface-soft: #f4f7ff;
+  --line: #e3e7f2;
+  --line-strong: #cfd9ef;
+  --ink: #0c1224;
+  --muted: #5d6682;
+  --primary: #1e4af5;
+  --primary-soft: #5fa9ff;
+  --accent: #1bb36f;
+  --shadow: 0 24px 60px rgba(12, 18, 36, 0.1);
+  font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top left, rgba(30, 74, 245, 0.16), transparent 30%),
+    radial-gradient(circle at top right, rgba(27, 179, 111, 0.12), transparent 26%),
+    linear-gradient(180deg, #fbfcff 0%, #f4f7ff 48%, #edf2fb 100%);
 }
 
 * {
@@ -10,7 +26,10 @@
 
 body {
   margin: 0;
-  background: #f6f7f8;
+  background:
+    radial-gradient(circle at top left, rgba(30, 74, 245, 0.16), transparent 30%),
+    radial-gradient(circle at top right, rgba(27, 179, 111, 0.12), transparent 26%),
+    linear-gradient(180deg, #fbfcff 0%, #f4f7ff 48%, #edf2fb 100%);
 }
 
 a {
@@ -19,64 +38,82 @@ a {
 }
 
 code {
-  font-family: 'SFMono-Regular', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-family: "DM Mono", "SFMono-Regular", Menlo, monospace;
   font-size: 0.92em;
 }
 
 .app {
   min-height: 100vh;
-  padding: 48px 6vw 80px;
-  background:
-    radial-gradient(circle at top left, rgba(255, 255, 255, 0.95), transparent 38%),
-    linear-gradient(180deg, #f9fafb 0%, #edf2f7 42%, #e3e8ef 100%);
+  padding: 48px clamp(20px, 6vw, 80px) 84px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.app-header,
+.app-main {
+  width: min(1380px, 100%);
+  margin: 0 auto;
 }
 
 .app-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(320px, 400px);
   gap: 24px;
-  flex-wrap: wrap;
-  margin-bottom: 32px;
+  align-items: stretch;
 }
 
 .hero-copy {
-  max-width: 560px;
+  padding: clamp(28px, 4vw, 40px);
+  border-radius: 30px;
+  border: 1px solid var(--line);
+  background:
+    linear-gradient(135deg, rgba(30, 74, 245, 0.14), rgba(255, 255, 255, 0.96) 55%, rgba(27, 179, 111, 0.12)),
+    var(--surface-strong);
+  box-shadow: var(--shadow);
 }
 
 .header-actions {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: stretch;
   gap: 16px;
 }
 
 .app-nav {
   display: flex;
+  justify-content: flex-end;
   gap: 12px;
   flex-wrap: wrap;
 }
 
 .nav-link {
-  padding: 8px 16px;
+  padding: 10px 16px;
   border-radius: 999px;
-  border: 1px solid #d7dde5;
-  background: #ffffff;
-  color: #374151;
-  font-weight: 600;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.76);
+  color: var(--muted);
+  font-weight: 700;
   font-size: 0.95rem;
-  transition: all 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    background 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .nav-link:hover {
-  border-color: #111827;
-  color: #111827;
+  border-color: rgba(30, 74, 245, 0.28);
+  color: var(--primary);
+  transform: translateY(-1px);
 }
 
 .nav-link.active {
-  background: #0f172a;
+  border-color: transparent;
+  background: linear-gradient(135deg, var(--primary), #1940d6);
   color: #ffffff;
-  border-color: #0f172a;
+  box-shadow: 0 16px 28px rgba(30, 74, 245, 0.24);
 }
 
 .app-main {
@@ -87,32 +124,39 @@ code {
 
 .eyebrow {
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: 0.75rem;
-  color: #4b5563;
-  margin: 0 0 8px;
+  letter-spacing: 0.22em;
+  font-size: 0.72rem;
+  color: var(--primary);
+  margin: 0 0 10px;
+  font-weight: 700;
 }
 
 h1 {
-  font-size: clamp(2.2rem, 4vw, 3.4rem);
-  margin: 0 0 8px;
+  margin: 0 0 12px;
+  font-size: clamp(2.4rem, 4.5vw, 4rem);
+  line-height: 1.04;
+  letter-spacing: -0.03em;
 }
 
 h2 {
-  margin: 0 0 8px;
-  font-size: 1.4rem;
+  margin: 0 0 10px;
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  line-height: 1.12;
+  letter-spacing: -0.02em;
 }
 
 h3 {
   margin: 0 0 12px;
-  font-size: 1.15rem;
+  font-size: 1.1rem;
+  line-height: 1.2;
 }
 
 .subhead {
-  font-size: 1.05rem;
-  color: #374151;
+  font-size: 1.02rem;
+  color: var(--muted);
   margin: 0;
-  max-width: 560px;
+  max-width: 60ch;
+  line-height: 1.72;
 }
 
 .page {
@@ -130,26 +174,25 @@ h3 {
 }
 
 .card {
-  padding: 20px;
-  border-radius: 16px;
-  background: #ffffff;
-  border: 1px solid #dbe2ea;
-  box-shadow: 0 12px 32px rgba(12, 15, 18, 0.08);
+  padding: 24px;
+  border-radius: 24px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
 }
 
 .session-card {
   width: min(420px, 100%);
-  padding: 16px 18px;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid #d7dde5;
-  box-shadow: 0 18px 40px rgba(12, 15, 18, 0.08);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 247, 255, 0.94)),
+    var(--surface-strong);
 }
 
 .hero-panel {
   background:
-    linear-gradient(135deg, rgba(15, 23, 42, 0.05), rgba(37, 99, 235, 0.08)),
-    #ffffff;
+    linear-gradient(135deg, rgba(30, 74, 245, 0.1), rgba(255, 255, 255, 0.98) 56%, rgba(27, 179, 111, 0.1)),
+    var(--surface-strong);
 }
 
 .card-header {
@@ -187,36 +230,47 @@ h3 {
 
 .input,
 .select {
-  border-radius: 10px;
-  border: 1px solid #d1d5db;
-  padding: 8px 12px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  padding: 10px 14px;
   font-size: 0.95rem;
   min-width: 220px;
-  background: #ffffff;
+  background: var(--surface-strong);
+  color: var(--ink);
 }
 
 .button {
   border: 0;
-  border-radius: 10px;
-  padding: 8px 14px;
+  border-radius: 14px;
+  padding: 10px 16px;
   font-size: 0.95rem;
   font-weight: 700;
   cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
 }
 
 .button:disabled {
   cursor: wait;
-  opacity: 0.7;
+  opacity: 0.72;
 }
 
 .button--primary {
-  background: #111827;
+  background: linear-gradient(135deg, var(--primary), #1940d6);
   color: #ffffff;
+  box-shadow: 0 16px 28px rgba(30, 74, 245, 0.24);
 }
 
 .button--secondary {
-  background: #e5e7eb;
-  color: #111827;
+  background: var(--surface-strong);
+  color: var(--ink);
+  border: 1px solid var(--line);
 }
 
 .persona-card {
@@ -250,20 +304,21 @@ h3 {
 .table th,
 .table td {
   text-align: left;
-  padding: 10px 12px;
-  border-bottom: 1px solid #e5e7eb;
+  padding: 12px;
+  border-bottom: 1px solid var(--line);
+  vertical-align: top;
 }
 
 .table thead {
-  background: #f9fafb;
-  color: #374151;
-  font-size: 0.85rem;
+  background: rgba(244, 247, 255, 0.92);
+  color: var(--muted);
+  font-size: 0.82rem;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
 }
 
 .table tbody tr:hover {
-  background: #f9fafb;
+  background: rgba(30, 74, 245, 0.04);
 }
 
 .table tbody tr.clickable {
@@ -274,49 +329,41 @@ h3 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 10px;
+  padding: 5px 11px;
   border-radius: 999px;
   font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
+  font-weight: 800;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  background: #f3f4f6;
-  color: #374151;
+  background: rgba(12, 18, 36, 0.06);
+  color: var(--muted);
 }
 
 .badge--customer {
-  background: #dbeafe;
-  color: #1d4ed8;
+  background: rgba(30, 74, 245, 0.12);
+  color: var(--primary);
 }
 
-.badge--active {
-  background: #dcfce7;
-  color: #166534;
+.badge--active,
+.badge--completed {
+  background: rgba(27, 179, 111, 0.14);
+  color: #0f7a4a;
 }
 
-.badge--inactive {
-  background: #fee2e2;
-  color: #991b1b;
+.badge--inactive,
+.badge--failed {
+  background: rgba(220, 38, 38, 0.1);
+  color: #b42318;
 }
 
 .badge--pending {
-  background: #fef3c7;
-  color: #92400e;
-}
-
-.badge--completed {
-  background: #dbeafe;
-  color: #1e3a8a;
-}
-
-.badge--failed {
-  background: #fee2e2;
-  color: #991b1b;
+  background: rgba(217, 119, 6, 0.12);
+  color: #b45309;
 }
 
 .badge--refunded {
-  background: #ede9fe;
-  color: #5b21b6;
+  background: rgba(76, 81, 255, 0.1);
+  color: #4254d0;
 }
 
 .status {
@@ -331,27 +378,28 @@ h3 {
 }
 
 .status.ok {
-  background: #dcfce7;
-  color: #166534;
+  background: rgba(27, 179, 111, 0.14);
+  color: #0f7a4a;
 }
 
 .status.down {
-  background: #fee2e2;
-  color: #991b1b;
+  background: rgba(220, 38, 38, 0.1);
+  color: #b42318;
 }
 
 .label {
   margin: 0 0 4px;
-  font-size: 0.8rem;
+  font-size: 0.76rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #6b7280;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  font-weight: 700;
 }
 
 .value {
   margin: 0;
   font-size: 1rem;
-  color: #111827;
+  color: var(--ink);
 }
 
 .detail-list {
@@ -374,64 +422,80 @@ h3 {
 }
 
 .summary-card {
-  border-radius: 16px;
+  border-radius: 20px;
+  background: var(--surface-soft);
+  border-color: rgba(30, 74, 245, 0.08);
+  box-shadow: none;
 }
 
 .summary-card .muted {
-  line-height: 1.5;
+  line-height: 1.6;
 }
 
 .state {
   margin: 12px 0 0;
-  color: #374151;
+  color: var(--muted);
 }
 
 .state.error {
-  color: #b91c1c;
+  color: #b42318;
 }
 
 .muted {
-  color: #6b7280;
+  color: var(--muted);
   margin: 0;
 }
 
 .session-user {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.14rem;
   font-weight: 700;
-  color: #111827;
+  color: var(--ink);
 }
 
 .session-note {
   margin: 10px 0 0;
-  font-size: 0.82rem;
-  color: #4b5563;
+  font-size: 0.84rem;
+  line-height: 1.65;
+  color: var(--muted);
 }
 
 .link {
-  color: #2563eb;
-  font-weight: 600;
+  color: var(--primary);
+  font-weight: 700;
 }
 
 .link:hover {
   text-decoration: underline;
 }
 
-@media (max-width: 720px) {
-  .app {
-    padding: 32px 6vw 64px;
+@media (max-width: 920px) {
+  .app-header {
+    grid-template-columns: 1fr;
   }
 
-  .header-actions {
+  .app-nav {
+    justify-content: flex-start;
+  }
+
+  .session-card {
     width: 100%;
-    align-items: stretch;
+  }
+}
+
+@media (max-width: 720px) {
+  .app {
+    padding: 28px 16px 60px;
+  }
+
+  .card,
+  .hero-copy {
+    padding: 20px;
+    border-radius: 22px;
   }
 
   .input,
-  .select {
-    min-width: 100%;
-  }
-
+  .select,
   .button {
     width: 100%;
   }

--- a/genxapi.config.json
+++ b/genxapi.config.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://raw.githubusercontent.com/genxapi/genxapi/main/schemas/genxapi.schema.json",
+  "$schema": "https://raw.githubusercontent.com/genxapi/genxapi/main/packages/cli/schemas/genxapi.schema.json",
   "project": {
-    "name": "genxapi-ecosystem-payments-sdk",
+    "name": "@genxapi-labs/ecosystem-payments-sdk",
     "directory": "./sdk/payments-sdk",
     "template": "orval",
     "output": "./src",

--- a/genxapi.users.config.json
+++ b/genxapi.users.config.json
@@ -1,8 +1,8 @@
 {
-  "$schema": "https://raw.githubusercontent.com/genxapi/genxapi/main/schemas/genxapi.schema.json",
+  "$schema": "https://raw.githubusercontent.com/genxapi/genxapi/main/packages/cli/schemas/genxapi.schema.json",
   "logLevel": "info",
   "project": {
-    "name": "@genxapi/ecosystem-users-sdk",
+    "name": "@genxapi-labs/ecosystem-users-sdk",
     "directory": "./sdk/users-sdk",
     "template": "orval",
     "output": "./src",

--- a/libs/auth-client/package.json
+++ b/libs/auth-client/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@genxapi/ecosystem-auth-client",
+  "name": "@genxapi-labs/ecosystem-auth-client",
   "version": "0.1.0",
-  "description": "Shared auth-service client helpers for the GenX API ecosystem demo",
+  "description": "Shared auth-service session helpers for the GenX API ecosystem demo",
   "private": true,
   "main": "index.js",
   "types": "index.d.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
       "name": "genxapi-ecosystem-demo",
       "version": "0.0.0",
       "dependencies": {
-        "@genxapi/ecosystem-auth-client": "file:libs/auth-client",
-        "@genxapi/ecosystem-users-sdk": "file:sdk/users-sdk",
+        "@genxapi-labs/ecosystem-auth-client": "file:libs/auth-client",
+        "@genxapi-labs/ecosystem-payments-sdk": "file:sdk/payments-sdk",
+        "@genxapi-labs/ecosystem-users-sdk": "file:sdk/users-sdk",
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/swagger": "^7.0.0",
         "@tanstack/react-query": "^5.65.1",
         "@tanstack/react-query-devtools": "^5.65.1",
-        "genxapi-ecosystem-payments-sdk": "file:sdk/payments-sdk",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3",
@@ -40,7 +40,7 @@
       }
     },
     "libs/auth-client": {
-      "name": "@genxapi/ecosystem-auth-client",
+      "name": "@genxapi-labs/ecosystem-auth-client",
       "version": "0.1.0"
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -948,6 +948,18 @@
         "npm": ">=9.0.0"
       }
     },
+    "node_modules/@genxapi-labs/ecosystem-auth-client": {
+      "resolved": "libs/auth-client",
+      "link": true
+    },
+    "node_modules/@genxapi-labs/ecosystem-payments-sdk": {
+      "resolved": "sdk/payments-sdk",
+      "link": true
+    },
+    "node_modules/@genxapi-labs/ecosystem-users-sdk": {
+      "resolved": "sdk/users-sdk",
+      "link": true
+    },
     "node_modules/@genxapi/cli": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@genxapi/cli/-/cli-0.2.0.tgz",
@@ -1197,14 +1209,6 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
-    },
-    "node_modules/@genxapi/ecosystem-auth-client": {
-      "resolved": "libs/auth-client",
-      "link": true
-    },
-    "node_modules/@genxapi/ecosystem-users-sdk": {
-      "resolved": "sdk/users-sdk",
-      "link": true
     },
     "node_modules/@genxapi/template-kubb": {
       "version": "0.1.0",
@@ -11652,10 +11656,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/genxapi-ecosystem-payments-sdk": {
-      "resolved": "sdk/payments-sdk",
-      "link": true
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -17423,7 +17423,7 @@
       }
     },
     "sdk/payments-sdk": {
-      "name": "genxapi-ecosystem-payments-sdk",
+      "name": "@genxapi-labs/ecosystem-payments-sdk",
       "version": "0.1.0",
       "devDependencies": {
         "@faker-js/faker": "^9.4.0",
@@ -17472,7 +17472,7 @@
       }
     },
     "sdk/users-sdk": {
-      "name": "@genxapi/ecosystem-users-sdk",
+      "name": "@genxapi-labs/ecosystem-users-sdk",
       "version": "0.1.0",
       "devDependencies": {
         "@faker-js/faker": "^9.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genxapi-ecosystem-demo",
-  "description": "Role-aware GenX API ecosystem demo for service-owned contracts, generated SDKs, and multi-app adoption.",
+  "description": "End-to-end GenX API ecosystem demo for contract publication, SDK generation, and multi-consumer adoption.",
   "version": "0.0.0",
   "private": true,
   "scripts": {
@@ -27,15 +27,15 @@
     "graph": "nx graph"
   },
   "dependencies": {
-    "@genxapi/ecosystem-auth-client": "file:libs/auth-client",
-    "@genxapi/ecosystem-users-sdk": "file:sdk/users-sdk",
+    "@genxapi-labs/ecosystem-auth-client": "file:libs/auth-client",
+    "@genxapi-labs/ecosystem-users-sdk": "file:sdk/users-sdk",
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^7.0.0",
     "@tanstack/react-query": "^5.65.1",
     "@tanstack/react-query-devtools": "^5.65.1",
-    "genxapi-ecosystem-payments-sdk": "file:sdk/payments-sdk",
+    "@genxapi-labs/ecosystem-payments-sdk": "file:sdk/payments-sdk",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",

--- a/sdk/payments-sdk/README.md
+++ b/sdk/payments-sdk/README.md
@@ -1,6 +1,9 @@
-# genxapi-ecosystem-payments-sdk
+# @genxapi-labs/ecosystem-payments-sdk
 
-Generated payments client plus a thin handwritten runtime adapter.
+Generated payments SDK package plus a thin handwritten runtime adapter.
+
+This package is part of the end-to-end workflow demonstrated in [`genxapi-ecosystem-demo`](https://github.com/genxapi/genxapi-ecosystem-demo): service-owned contract snapshot -> GenX API generation -> consumer app adoption.
+It is demo-only. The core open source product packages stay under the `@genxapi/*` scope, while ecosystem demo artifacts live under `@genxapi-labs/*`.
 
 ## Generated vs handwritten
 
@@ -10,7 +13,7 @@ Generated payments client plus a thin handwritten runtime adapter.
 ## Usage
 
 ```ts
-import { createPaymentsSdk } from 'genxapi-ecosystem-payments-sdk';
+import { createPaymentsSdk } from '@genxapi-labs/ecosystem-payments-sdk';
 
 const paymentsSdk = createPaymentsSdk({
   baseUrl: 'https://api.example.com/payments',

--- a/sdk/payments-sdk/package-lock.json
+++ b/sdk/payments-sdk/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "genxapi-ecosystem-payments-sdk",
+  "name": "@genxapi-labs/ecosystem-payments-sdk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "genxapi-ecosystem-payments-sdk",
+      "name": "@genxapi-labs/ecosystem-payments-sdk",
       "version": "0.1.0",
       "devDependencies": {
         "@faker-js/faker": "^9.4.0",

--- a/sdk/payments-sdk/package.json
+++ b/sdk/payments-sdk/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "genxapi-ecosystem-payments-sdk",
+  "name": "@genxapi-labs/ecosystem-payments-sdk",
   "version": "0.1.0",
-  "description": "Generated payments SDK for the GenX API ecosystem demo",
+  "description": "Generated payments SDK package for the GenX API ecosystem demo",
   "type": "module",
   "exports": {
     "./package.json": "./package.json",

--- a/sdk/users-sdk/README.md
+++ b/sdk/users-sdk/README.md
@@ -1,6 +1,10 @@
-# @genxapi/ecosystem-users-sdk
+# @genxapi-labs/ecosystem-users-sdk
 
-Generated users client plus a thin handwritten runtime adapter.
+Generated users SDK package plus a thin handwritten runtime adapter.
+
+This package is demo-only. The core open source product packages stay under the `@genxapi/*` scope, while ecosystem demo artifacts live under `@genxapi-labs/*`.
+
+This package is part of the end-to-end workflow demonstrated in [`genxapi-ecosystem-demo`](https://github.com/genxapi/genxapi-ecosystem-demo): service-owned contract snapshot -> GenX API generation -> consumer app adoption.
 
 ## Generated vs handwritten
 
@@ -10,7 +14,7 @@ Generated users client plus a thin handwritten runtime adapter.
 ## Usage
 
 ```ts
-import { createUsersSdk } from '@genxapi/ecosystem-users-sdk';
+import { createUsersSdk } from '@genxapi-labs/ecosystem-users-sdk';
 
 const usersSdk = createUsersSdk({
   baseUrl: 'https://api.example.com/users',

--- a/sdk/users-sdk/package-lock.json
+++ b/sdk/users-sdk/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@genxapi/ecosystem-users-sdk",
+  "name": "@genxapi-labs/ecosystem-users-sdk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@genxapi/ecosystem-users-sdk",
+      "name": "@genxapi-labs/ecosystem-users-sdk",
       "version": "0.1.0",
       "devDependencies": {
         "@faker-js/faker": "^9.4.0",

--- a/sdk/users-sdk/package.json
+++ b/sdk/users-sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@genxapi/ecosystem-users-sdk",
+  "name": "@genxapi-labs/ecosystem-users-sdk",
   "version": "0.1.0",
   "description": "Generated users SDK for the GenX API ecosystem demo",
   "type": "module",


### PR DESCRIPTION
Aligns the GenX API ecosystem story across `genxapi`, `genxapi-action`, and `genxapi-ecosystem-demo`, while keeping the demo clearly separate from the core open source package surface.

The main boundary change is that demo-local packages now live under `@genxapi-labs/*` instead of `@genxapi/*`, so the core namespace remains reserved for the primary GenX API product.

## What Changed

- clarified the role of each repository across the three READMEs
- tightened package and repo descriptions for consistency
- updated the demo repo to present itself as the end-to-end proof repo, not the core product
- moved demo-only package names and imports to `@genxapi-labs/*`
- fixed demo config/schema and package metadata inconsistencies
- refreshed web, mobile, and backoffice demo styling to better match the GenX API visual direction
- aligned app copy around clearer terms like SDK packages, customer surfaces, and operations console

## Why

This PR is about ecosystem cohesion and trust, not new product features. This PR makes the repos easier to understand from any entry point while avoiding confusion between:

- core consumable GenX API packages under `@genxapi/*`
- demo and experimental ecosystem artefacts under `@genxapi-labs/*`

## Verification

- ran `npm install` in the demo repo root
- ran `npm install` in `apps/mobile-app`
- ran `npm run build:browser-apps`

The browser apps build successfully after the package rename. Install produced Node engine warnings in this environment because it is on Node 18 while some dependencies now expect Node 20+, but the demo browser build still passed.